### PR TITLE
fix: Smoothen smart auto-scroll of TerminalTextArea

### DIFF
--- a/src/jrdev/ui/tui/message_bubble.py
+++ b/src/jrdev/ui/tui/message_bubble.py
@@ -50,7 +50,7 @@ class MessageBubble(Vertical):
 
     def compose(self) -> ComposeResult:
         """Compose the message bubble with a text area and a copy button."""
-        self.text_area = TerminalTextArea(id=f"{self.id}-text_area", language="markdown")
+        self.text_area = TerminalTextArea(_id=f"{self.id}-text_area", language="markdown")
         yield self.text_area
         yield Button("Copy Selection")
 

--- a/src/jrdev/ui/tui/terminal_output_widget.py
+++ b/src/jrdev/ui/tui/terminal_output_widget.py
@@ -37,7 +37,7 @@ class TerminalOutputWidget(Widget):
         super().__init__(id=id)
         # output_widget_mode provides the output widget, without the input widget
         self.output_widget_mode = output_widget_mode
-        self.terminal_output = TerminalTextArea(id="terminal_output", language="markdown")
+        self.terminal_output = TerminalTextArea(_id="terminal_output", language="markdown")
         self.copy_button = Button(label="Copy Selection", id="copy_button")
         if not self.output_widget_mode:
             self.terminal_input = CommandTextArea(placeholder="Enter Command", id="cmd_input")

--- a/src/jrdev/ui/tui/terminal_text_area.py
+++ b/src/jrdev/ui/tui/terminal_text_area.py
@@ -1,69 +1,47 @@
-from textual.document._document import Selection
-from textual.geometry import Offset
-from textual.widgets import TextArea
-from textual import events
-
-from textual.document._document import Selection
-
 import logging
+
+from textual import events
+from textual.geometry import Offset
+from textual.reactive import Reactive, reactive
+from textual.widgets import TextArea
+
 # Get the global logger instance
 logger = logging.getLogger("jrdev")
 
-class TerminalTextArea(TextArea):
 
-    def __init__(self, id: str, language: str):
-        super().__init__(id=id, language=language)
+class TerminalTextArea(TextArea):
+    follow_tail: Reactive[bool] = reactive(True, init=True)  # replaces _auto_scroll
+    _TOLERANCE = 1  # px / rows
+
+    def __init__(self, _id: str, language: str):
+        super().__init__(id=_id, language=language)
         self.cursor_blink = False
         # start in auto‑scroll mode
         self._auto_scroll = True
 
-    def _on_mouse_scroll_up(self, event: events.MouseScrollUp) -> None:
-        self._auto_scroll = False
-        super()._on_mouse_scroll_up(event)
+    # ---------- helpers -------------------------------------------------
+    def _is_at_bottom(self) -> bool:
+        max_scroll = max(self.virtual_size.height - self.size.height, 0)
+        return self.scroll_y >= max_scroll - self._TOLERANCE
 
-    def _on_mouse_scroll_down(self, event: events.MouseScrollDown) -> None:
-        self._auto_scroll = False
-        super()._on_mouse_scroll_down(event)
+    def _after_any_scroll(self) -> None:
+        """Run after *every* wheel / key / drag to (re)arm follow-tail."""
+        self.follow_tail = self._is_at_bottom()  # True *or* False
 
-    def _on_key(self, event: events.Key) -> None:
+    # ---------- event hooks ---------------------------------------------
+    def _watch_scroll_y(self) -> None:
+        super()._watch_scroll_y()
+        self._after_any_scroll()
+
+    async def _on_key(self, event: events.Key) -> None:
+        await super()._on_key(event)
         # arrow‐up/down, page‐up/down are also manual scroll triggers
         if event.key in ("up", "down", "pageup", "pagedown"):
-            self._auto_scroll = False
-        super()._on_key(event)
+            self._after_any_scroll()
 
     def append_text(self, new_text: str) -> None:
-        # 1) Remember where we were
-        prev_scroll = self.scroll_y
+        self.insert(new_text, location=self.document.end)
+        self.call_after_refresh(lambda: self.scroll_end(animate=False) if self.follow_tail else None)
 
-        # 2) Insert in‑place so we don't reload the document
-        end = self.document.end
-        self.insert(new_text, location=end)
-
-        # 3) After the document actually re‑flows, either
-        #    a) go to the bottom if we are still in auto‑scroll mode
-        #    b) restore the exact scroll position if not
-        def adjust_scroll():
-            max_scroll = max(self.virtual_size.height - self.size.height, 0)
-            if self._auto_scroll:
-                # still in auto‑scroll mode → always jump to bottom
-                self.scroll_y = max_scroll
-            else:
-                # manual‑scroll mode → put them back exactly where they were
-                # (but clamp into [0, max_scroll])
-                self.scroll_y = min(prev_scroll, max_scroll)
-
-        self.call_after_refresh(adjust_scroll)
-
-        # 4) And force a redraw
-        self.refresh()
-
-        # 5) If we *were* at the bottom before we inserted, we can
-        #    re‑enable auto‑scroll for next time.  Otherwise leave it off.
-        max_scroll = max(self.virtual_size.height - self.size.height, 0)
-        if prev_scroll >= max_scroll - 1:
-            self._auto_scroll = True
-
-    def scroll_cursor_visible(
-        self, center: bool = False, animate: bool = False
-    ) -> Offset:
+    def scroll_cursor_visible(self, center: bool = False, animate: bool = False) -> Offset:
         return Offset()


### PR DESCRIPTION
refactor underlying auto-scroll handling to use reactive state:
- replace _auto_scroll with follow_tail reactive property (default True)
- introduce _is_at_bottom() helper based on tolerance
- centralize scroll state update in _after_any_scroll()
- simplify text appending by removing manual scroll calculations

This creates a more robust way to track when the user is engaged at the log tail versus manually navigating, and will lay the foundation for explicit "tail mode" toggle controls in UI elements.