### PR TITLE
Add Git Installation Check to Git Tools Screen

### DIFF
--- a/src/jrdev/utils/git_utils.py
+++ b/src/jrdev/utils/git_utils.py
@@ -300,3 +300,28 @@ def get_staged_diff() -> Optional[str]:
     except Exception as e:
         logger.error(f"An unexpected error occurred while getting staged git diff: {e}")
         return None
+
+def is_git_installed() -> bool:
+    """
+    Checks if git is installed by attempting to run 'git --version'.
+
+    Returns:
+        True if git is installed and accessible, False otherwise.
+    """
+    try:
+        subprocess.check_output(
+            ["git", "--version"],
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=5
+        )
+        return True
+    except FileNotFoundError:
+        logger.error("Git is not installed or not in PATH.")
+        return False
+    except subprocess.TimeoutExpired:
+        logger.error("Git version check timed out.")
+        return False
+    except Exception as e:
+        logger.error(f"Unexpected error checking git installation: {e}")
+        return False


### PR DESCRIPTION
## Overview

This pull request introduces a check to determine if Git is installed on the system before enabling Git-related features in the Git Tools screen. The change addresses potential errors and improves usability by providing clear instructions when Git is unavailable, ensuring a smoother experience in environments where Git might not be present.

## What This Means for Users

Users who attempt to access the Git Tools screen without Git installed will now see a prominent warning message with platform-specific installation instructions instead of encountering runtime errors or disabled features without explanation. This prevents confusion and guides users toward resolving the issue, allowing them to quickly enable full Git functionality after installation.

## A Closer Look at the Changes

The updates focus on adding a utility function for Git detection and integrating it into the screen's initialization logic to handle the absence of Git gracefully.

- **New Functionality**: A new `is_git_installed` function has been added to `git_utils.py`. This function verifies Git's presence by running `git --version` via subprocess, handling cases like file not found errors, timeouts, or other exceptions to return a boolean indicating availability. This utility supports reliable checks without assuming Git's installation.

- **Code Refinements & Improvements**: In `git_tools_screen.py`, the `on_mount` method now calls `is_git_installed` early in the process. If Git is not detected, it disables the overview, PR summary, and PR review buttons, clears the overview view, and mounts a MarkdownViewer with a warning message. The message includes tailored installation steps for macOS, Linux, and Windows. If Git is installed, the method proceeds with focusing the unstaged files list as before. This refactoring enhances error handling and user feedback while maintaining existing behavior when Git is available.

closes #96 

`Generated by JrDev AI using x-ai/grok-4`