### PR TITLE
feat: add git commit history and diff functionality

### DIFF
--- a/src/jrdev/ui/tui/git_overview_widget.py
+++ b/src/jrdev/ui/tui/git_overview_widget.py
@@ -25,6 +25,8 @@ from jrdev.utils.git_utils import (
     unstage_file,
     reset_unstaged_changes,
     perform_commit,
+    get_commit_history,
+    get_commit_diff,
 )
 
 logger = logging.getLogger("jrdev")
@@ -41,6 +43,14 @@ class FileListItem(ListItem):
         self.is_untracked = is_untracked
 
 
+class CommitListItem(ListItem):
+    """A ListItem that holds a commit hash."""
+
+    def __init__(self, commit_hash: str, commit_subject: str) -> None:
+        super().__init__(Label(f"[yellow]{commit_hash}[/] {commit_subject}"))
+        self.commit_hash = commit_hash
+
+
 class GitOverviewWidget(Static):
     """A widget to display git status and file diffs."""
 
@@ -49,7 +59,15 @@ class GitOverviewWidget(Static):
         layout: horizontal;
         height: 2fr;
         padding: 0;
+        margin: 0;
         border: none;
+    }
+    
+    #main-layout {
+        border: none;
+        margin: 0;
+        padding: 0;
+        height: 100%;
     }
 
     #git-status-lists-layout {
@@ -57,7 +75,6 @@ class GitOverviewWidget(Static):
         max-width: 40;
         height: 100%;
         padding: 0;
-        overflow-y: auto;
     }
     
     #git-diff-layout {
@@ -110,16 +127,19 @@ class GitOverviewWidget(Static):
         margin-right: 1;
     }
     
-    #unstage-buttons-layout #staged-buttons-layout {
-        height:1;
+    #unstage-buttons-layout, #staged-buttons-layout {
         border: none;
+        height: 1;
         margin: 0;
         padding: 0;
     }
 
-    #branch-label {
-        height: 2;
-        padding: 1 0 0 1;
+    .top-labels {
+        height: 1;
+        padding: 0 0 0 1;
+        margin: 0;
+        text-style: bold;
+        color: $text;
     }
 
     .status-list-title {
@@ -140,6 +160,32 @@ class GitOverviewWidget(Static):
         margin-bottom: 0;
         height: 1fr;
         overflow-x: auto;
+        overflow-y: auto;
+    }
+    
+    #staged-list-layout, #unstaged-list-layout  {
+        border: none;
+        height: auto;
+        max-height: 30%;
+        min-height: 0;
+        padding: 0;
+        margin: 0;
+    }
+    
+    #commit-history-list {
+        border: round $panel;
+        margin: 0;
+        height: 1fr;
+        overflow-x: auto;
+        overflow-y: auto;
+    }
+    
+    #commit-history-layout {
+        border: none;
+        height: 1fr;
+        min-height: 30%;
+        padding: 0 0 0 0;
+        margin: 0;
     }
 
     #diff-log {
@@ -154,6 +200,7 @@ class GitOverviewWidget(Static):
         max-width: 9;
         padding: 0;
         margin-left: 1;
+        height: 1;
     }
     
     #generate-commit-msg-button {
@@ -205,27 +252,40 @@ class GitOverviewWidget(Static):
         )
         self.button_cancel_commit = Button("Cancel", id="cancel-commit-button")
 
+        self.unstage_list_layout = Vertical(id="unstaged-list-layout")
+        self.unstaged_list_title = Label("Unstaged Files", classes="status-list-title")
+        self.unstaged_list = ListView(id="unstaged-files-list")
+        self.unstaged_buttons_layout = Horizontal(id="unstage-buttons-layout")
+
     def compose(self) -> ComposeResult:
         """Compose the widget's layout."""
-        with Horizontal():
+        with Horizontal(id="main-layout"):
+
             with Vertical(id="git-status-lists-layout"):
-                yield Label("Branch: ", id="branch-label", classes="status-list-title")
-                yield Label("Unstaged Files", classes="status-list-title")
-                yield ListView(id="unstaged-files-list")
-                with Horizontal(id="unstage-buttons-layout"):
-                    yield self.button_stage
-                    yield self.button_reset
-                    yield self.reset_confirmation_label
-                    yield self.button_confirm_reset
-                    yield self.button_cancel_reset
-                yield Label("Staged Files", classes="status-list-title")
-                yield ListView(id="staged-files-list")
-                with Horizontal(id="staged-buttons-layout"):
-                    yield self.button_unstage
-                    yield self.button_commit
+                yield Label("Branch: ", id="branch-label", classes="top-labels")
+                with self.unstage_list_layout:
+                    yield self.unstaged_list_title
+                    yield self.unstaged_list
+                    with self.unstaged_buttons_layout:
+                        yield self.button_stage
+                        yield self.button_reset
+                        yield self.reset_confirmation_label
+                        yield self.button_confirm_reset
+                        yield self.button_cancel_reset
+
+                with Vertical(id="staged-list-layout"):
+                    yield Label("Staged Files", classes="status-list-title")
+                    yield ListView(id="staged-files-list")
+                    with Horizontal(id="staged-buttons-layout"):
+                        yield self.button_unstage
+                        yield self.button_commit
+
+                with Vertical(id="commit-history-layout"):
+                    yield Label("Commit History", classes="status-list-title")
+                    yield ListView(id="commit-history-list")
             with Vertical(id="git-diff-layout"):
                 with Vertical(id="diff-view"):
-                    yield Label("File Diff", id="file-label", classes="status-list-title")
+                    yield Label("File Diff", id="file-label", classes="top-labels")
                     yield RichLog(id="diff-log", highlight=False, markup=True)
 
                 with Vertical(id="commit-view"):
@@ -259,14 +319,17 @@ class GitOverviewWidget(Static):
 
         staged_list = self.query_one("#staged-files-list", ListView)
         unstaged_list = self.query_one("#unstaged-files-list", ListView)
+        commit_history_list = self.query_one("#commit-history-list", ListView)
         diff_log = self.query_one("#diff-log", RichLog)
 
         staged_list.clear()
         unstaged_list.clear()
+        commit_history_list.clear()
         diff_log.clear()
 
         staged_list.can_focus = False
         unstaged_list.can_focus = False
+        commit_history_list.can_focus = False
 
         # Use git_utils to get staged, unstaged, and untracked files.
         # This is the single source of truth for git status.
@@ -289,9 +352,27 @@ class GitOverviewWidget(Static):
             # Staged files can't be untracked.
             staged_list.append(FileListItem(filepath, staged=True, is_untracked=False))
 
+        # Populate commit history
+        commit_history = get_commit_history()
+        for commit_hash, commit_subject in commit_history:
+            commit_history_list.append(
+                CommitListItem(commit_hash, commit_subject)
+            )
+
+        # manual adjustment of heights on staged lists
+        if not staged_files:
+            staged_list.styles.height = "auto"
+        else:
+            staged_list.styles.height = "1fr"
+        if not unstaged_files:
+            unstaged_list.styles.height = "auto"
+        else:
+            unstaged_list.styles.height = "1fr"
+
+
     @on(ListView.Selected)
     def show_diff(self, event: ListView.Selected) -> None:
-        """When a file is selected, show its diff."""
+        """When a file or commit is selected, show its diff."""
         # If confirmation is active, cancel it to avoid weird UI states
         if self.button_confirm_reset.display:
             self._toggle_reset_confirmation(False)
@@ -302,60 +383,83 @@ class GitOverviewWidget(Static):
 
         staged_list = self.query_one("#staged-files-list", ListView)
         unstaged_list = self.query_one("#unstaged-files-list", ListView)
+        commit_history_list = self.query_one("#commit-history-list", ListView)
 
-        # Deselect item in the other list to avoid confusion
+        # Deselect items in other lists and manage button states
         if event.list_view.id == "staged-files-list":
-            if unstaged_list.index is not None:
-                unstaged_list.index = None
-
-            # Disable unstaged list buttons
+            if unstaged_list.index is not None: unstaged_list.index = None
+            if commit_history_list.index is not None: commit_history_list.index = None
             self.button_stage.disabled = True
             self.button_reset.disabled = True
-            # Enable staged list buttons
             self.button_unstage.disabled = False
-        else:  # unstaged-files-list
-            if staged_list.index is not None:
-                staged_list.index = None
-
-            # Enable unstaged list buttons
+        elif event.list_view.id == "unstaged-files-list":
+            if staged_list.index is not None: staged_list.index = None
+            if commit_history_list.index is not None: commit_history_list.index = None
             self.button_stage.disabled = False
             self.button_reset.disabled = False
-            # Enable staged list buttons
+            self.button_unstage.disabled = True
+        elif event.list_view.id == "commit-history-list":
+            if staged_list.index is not None: staged_list.index = None
+            if unstaged_list.index is not None: unstaged_list.index = None
+            self.button_stage.disabled = True
+            self.button_reset.disabled = True
             self.button_unstage.disabled = True
 
         item = event.item
-        file_label = self.query_one("#file-label", Label)
-        if not isinstance(item, FileListItem):
-            file_label.update(f"File Diff:")
-            return
-
-        file_label.update(f"File Diff: [green]{item.filepath}[/]")
-
         diff_log = self.query_one("#diff-log", RichLog)
+        file_label = self.query_one("#file-label", Label)
         diff_log.clear()
 
-        diff_content = get_file_diff(
-            item.filepath, staged=item.staged, is_untracked=item.is_untracked
-        )
+        if isinstance(item, FileListItem):
+            file_label.update(f"File Diff: [green]{item.filepath}[/]")
+            diff_content = get_file_diff(
+                item.filepath, staged=item.staged, is_untracked=item.is_untracked
+            )
+            if diff_content is None or not diff_content.strip():
+                diff_log.write(f"No changes to display for [bold]{item.filepath}[/].")
+                return
 
-        diff_log.clear()
-        if diff_content is None or not diff_content.strip():
-            diff_log.write(f"No changes to display for [bold]{item.filepath}[/].")
-            return
+            formatted_lines = []
+            for line in diff_content.splitlines():
+                escaped_line = line.replace("[", "\\[")
+                if line.startswith('+'):
+                    formatted_lines.append(f"[green]{escaped_line}[/green]")
+                elif line.startswith('-'):
+                    formatted_lines.append(f"[red]{escaped_line}[/red]")
+                elif line.startswith('@@'):
+                    formatted_lines.append(f"[cyan]{escaped_line}[/cyan]")
+                else:
+                    formatted_lines.append(escaped_line)
+            diff_log.write("\n".join(formatted_lines))
 
-        # Reuse diff formatting from CodeConfirmationScreen
-        formatted_lines = []
-        for line in diff_content.splitlines():
-            escaped_line = line.replace("[", "\\[")
-            if line.startswith('+'):
-                formatted_lines.append(f"[green]{escaped_line}[/green]")
-            elif line.startswith('-'):
-                formatted_lines.append(f"[red]{escaped_line}[/red]")
-            elif line.startswith('@@'):
-                formatted_lines.append(f"[cyan]{escaped_line}[/cyan]")
-            else:
-                formatted_lines.append(escaped_line)
-        diff_log.write("\n".join(formatted_lines))
+        elif isinstance(item, CommitListItem):
+            file_label.update(f"Commit Diff: [yellow]{item.commit_hash}[/]")
+            commit_diff_content = get_commit_diff(item.commit_hash)
+
+            if commit_diff_content is None or not commit_diff_content.strip():
+                diff_log.write(f"No diff to display for commit [bold]{item.commit_hash}[/].")
+                return
+
+            formatted_lines = []
+            for line in commit_diff_content.splitlines():
+                escaped_line = line.replace("[", "\\[")
+                # Special formatting for git show output
+                if line.startswith('commit '):
+                    formatted_lines.append(f"[yellow]{escaped_line}[/yellow]")
+                elif line.startswith('Author:') or line.startswith('Date:'):
+                    formatted_lines.append(f"[blue]{escaped_line}[/blue]")
+                elif line.startswith('+') and not line.startswith('+++'):
+                    formatted_lines.append(f"[green]{escaped_line}[/green]")
+                elif line.startswith('-') and not line.startswith('---'):
+                    formatted_lines.append(f"[red]{escaped_line}[/red]")
+                elif line.startswith('@@'):
+                    formatted_lines.append(f"[cyan]{escaped_line}[/cyan]")
+                else:
+                    formatted_lines.append(escaped_line)
+            diff_log.write("\n".join(formatted_lines))
+        else:
+            # Some other list item, maybe from a future list. Clear the view.
+            file_label.update("File Diff")
 
     @on(Button.Pressed, "#stage-button")
     def handle_stage_pressed(self):

--- a/src/jrdev/ui/tui/git_tools_screen.py
+++ b/src/jrdev/ui/tui/git_tools_screen.py
@@ -31,6 +31,7 @@ class GitToolsScreen(ModalScreen):
         background: $surface;
         border: round $accent;
         padding: 0;
+        margin: 0;
         layout: vertical; /* Main layout is vertical */
     }
 
@@ -50,15 +51,16 @@ class GitToolsScreen(ModalScreen):
 
     /* Container for sidebar and content */
     #main-content-horizontal {
-        height: 1fr;
+        height: 100%;
         layout: horizontal;
+        padding: 0;
     }
 
     #sidebar {
         width: 20;
         height: 100%;
         border-right: solid $panel;
-        padding: 1 0;
+        padding: 0 0;
         transition: width 0.2s out_expo;
     }
 
@@ -68,12 +70,13 @@ class GitToolsScreen(ModalScreen):
     }
 
     #sidebar-title {
-        height: 3;
-        padding: 0 1; /* Match ModelProfileScreen */
+        height: 2;
+        width: 1fr;
+        padding: 0 1;
         content-align: center middle;
         text-style: bold;
         color: $text;
-        border-bottom: solid $panel; /* Match ModelProfileScreen */
+        border-bottom: solid $panel;
     }
 
     .sidebar-button {
@@ -113,6 +116,7 @@ class GitToolsScreen(ModalScreen):
         width: 1fr;
         height: 100%;
         layout: vertical;
+        padding: 0;
     }
 
     /* View Containers */
@@ -121,9 +125,10 @@ class GitToolsScreen(ModalScreen):
     #pr-summary-view,
     #pr-review-view,
     #help-view { /* Added help-view */
-        height: 1fr; /* Take available space */
+        height: 100%; /* Take available space */
         display: block; /* Initially visible, will be controlled */
         padding: 0;
+        margin: 0;
         overflow-y: auto; /* Allow scrolling within view */
         overflow-x: hidden;
     }
@@ -185,7 +190,8 @@ class GitToolsScreen(ModalScreen):
     #summary-output-widget,
     #review-output-widget {
         height: 1fr; /* Take remaining space */
-        margin-bottom: 0;
+        margin: 0;
+        padding: 0;
         border: round $accent;
     }
     /* Style the inner TerminalTextArea */


### PR DESCRIPTION
- add `get_commit_history` function to retrieve the last 100 commits
- add `get_commit_diff` function to get the diff for a specific commit
- update UI styles and layout for better display of commit history and diffs
- adjust widget compositions and event handling for improved user experience