### PR TITLE
refactor: lazy import curses and simplify fallback CLI editor

### DIFF
--- a/src/jrdev/ui/cli/curses_editor.py
+++ b/src/jrdev/ui/cli/curses_editor.py
@@ -5,7 +5,6 @@ A simple curses-based text editor for editing multi-line text.
 Provides basic navigation, editing capabilities, and save/cancel options.
 """
 
-import curses
 from typing import Optional, Tuple
 
 
@@ -26,6 +25,7 @@ class CursesEditor:
     def run(self) -> Tuple[bool, Optional[str]]:
         """Run the editor and return (success, edited_text)."""
         try:
+            import curses
             # Initialize curses
             stdscr = curses.initscr()
             curses.noecho()  # Don't echo keypresses
@@ -264,6 +264,7 @@ class CursesEditor:
 def is_curses_available() -> bool:
     """Check if curses is available on the current platform."""
     try:
+        import curses
         curses.initscr()
         curses.endwin()
         return True


### PR DESCRIPTION
moved curses imports into run and is_curses_available to avoid import errors on unsupported platforms replaced termios/tty based fallback with a simple input() loop that ends on a double empty line and handles no-change cases