### PR TITLE
Refactor LLM Streaming and Provider Management for Enhanced Modularity

### DIFF
--- a/src/jrdev/commands/cost.py
+++ b/src/jrdev/commands/cost.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List, Tuple, cast
 
-from jrdev.core.usage import get_instance
+from jrdev.core.usage import get_token_tracker_instance
 from jrdev.models.model_utils import get_model_cost
 from jrdev.ui.ui import PrintType
 
@@ -122,7 +122,7 @@ async def handle_cost(app: Any, _cmd_parts: List[str], _worker_id: str) -> None:
     Usage:
       /cost
     """
-    usage_data = await get_instance().get_usage()
+    usage_data = await get_token_tracker_instance().get_usage()
     if not usage_data:
         app.ui.print_text("No usage data available. Try running some queries first.", PrintType.INFO)
         return

--- a/src/jrdev/commands/provider.py
+++ b/src/jrdev/commands/provider.py
@@ -1,5 +1,6 @@
 from typing import Any, List
 
+from jrdev.services import provider_factory
 from jrdev.ui.ui import PrintType
 from jrdev.utils.string_utils import is_valid_env_key, is_valid_name, is_valid_url
 
@@ -56,7 +57,7 @@ async def handle_provider(app: Any, args: List[str], _worker_id: str) -> None:
 
 
 def _handle_list(app: Any) -> None:
-    providers = app.state.clients.list_providers()
+    providers = provider_factory.list_providers()
     app.ui.print_text("API Providers:", PrintType.INFO)
     for p in providers:
         app.ui.print_text(f"  {p.name} (env_key: {p.env_key}, base_url: {p.base_url})", PrintType.INFO)
@@ -95,7 +96,7 @@ def _handle_add(app: Any, args: List[str]) -> None:
         "required": False,
         "default_profiles": {"profiles": {}, "default_profile": ""},
     }
-    app.state.clients.add_provider(provider_data)
+    provider_factory.add_provider(provider_data)
     app.ui.print_text(f"Provider '{name}' added successfully.", PrintType.SUCCESS)
     app.ui.providers_updated()
     app.refresh_model_list()
@@ -120,7 +121,7 @@ def _handle_edit(app: Any, args: List[str]) -> None:
         app.ui.print_text(f"Invalid base_url '{new_base_url}'. Must be a valid http(s) URL.", PrintType.ERROR)
         return
     updated_fields = {"env_key": new_env_key, "base_url": new_base_url}
-    app.state.clients.edit_provider(name, updated_fields)
+    provider_factory.edit_provider(name, updated_fields)
     app.ui.print_text(f"Provider '{name}' edited successfully.", PrintType.SUCCESS)
     app.ui.providers_updated()
 
@@ -130,7 +131,7 @@ def _handle_remove(app: Any, args: List[str]) -> None:
         app.ui.print_text("Usage: /provider remove <name>", PrintType.ERROR)
         return
     name = args[2]
-    app.state.clients.remove_provider(name)
+    provider_factory.remove_provider(name)
     app.ui.print_text(f"Provider '{name}' removed successfully.", PrintType.SUCCESS)
     app.ui.providers_updated()
     app.refresh_model_list()

--- a/src/jrdev/core/usage.py
+++ b/src/jrdev/core/usage.py
@@ -118,7 +118,7 @@ class Usage:
 _instance: Optional[Usage] = None
 
 
-def get_instance(save_path: Optional[str] = None) -> Usage:
+def get_token_tracker_instance(save_path: Optional[str] = None) -> Usage:
     """Get the global Usage instance.
 
     Args:

--- a/src/jrdev/services/llm_requests.py
+++ b/src/jrdev/services/llm_requests.py
@@ -1,258 +1,34 @@
-import time
-import tiktoken
-from typing import AsyncIterator
 from asyncio import CancelledError
-from jrdev.core.usage import get_instance
+from typing import AsyncIterator
 
+from jrdev.services.streaming.anthropic_streamer import AnthropicStreamer
+from jrdev.services.streaming.openai_streamer import OpenAIStreamer
 
-async def stream_openai_format(app, model, messages, task_id=None, print_stream=True, json_output=False, max_output_tokens=None) -> AsyncIterator[str]:
-    # Start timing the response
-    start_time = time.time()
-
-    log_msg = f"Sending request to {model} with {len(messages)} messages"
-    app.logger.info(log_msg)
-    
-    # Get the appropriate client
-    model_provider = None
-
-    # Find the model in AVAILABLE_MODELS
-    available_models = app.get_models()
-    for entry in available_models:
-        if entry["name"] == model:
-            model_provider = entry["provider"]
-            break
-
-    # token estimator
-    token_encoder = tiktoken.get_encoding("cl100k_base")
-
-    # Select the appropriate client based on provider
-    if model_provider not in app.state.clients.get_all_clients():
-        raise ValueError(f"No client for {model_provider}")
-    client = app.state.clients.get_client(model_provider)
-
-    # Create a streaming completion
-    kwargs = {
-        "model": model,
-        "messages": messages,
-        "stream": True,
-        "temperature": 0.0,
-        "extra_headers": {
-            "HTTP-Referer": "https://github.com/presstab/jrdev",
-            "X-Title": "JrDev"
-        }
-    }
-
-    if max_output_tokens:
-        kwargs["max_completion_tokens"] = max_output_tokens
-
-    if model_provider == "openai":
-        if "o3" in model or "o4-mini" in model:
-            kwargs["reasoning_effort"] = "high"
-            del kwargs["temperature"]
-        kwargs["stream_options"] = {"include_usage": True}
-    elif model == "qwen-2.5-qwq-32b":
-        kwargs["top_p"] = 0.95
-        kwargs["extra_body"] = {"venice_parameters": {"include_venice_system_prompt": False}, "frequency_penalty": 0.3}
-    elif model == "deepseek-r1-671b":
-        kwargs["extra_body"] = {"venice_parameters": {"include_venice_system_prompt": False}}
-    elif model == "deepseek-reasoner" or model == "deepseek-chat":
-        kwargs["max_tokens"] = 8000
-        if model == "deepseek-chat" and json_output:
-            kwargs["response_format"] = {"type": "json_object"}
-    elif model_provider == "venice":
-        kwargs["extra_body"] = {"venice_parameters": {"include_venice_system_prompt": False}}
-
-    stream = await client.chat.completions.create(**kwargs)
-
-    first_chunk = True
-    chunk_count = 0
-    log_interval = 100  # Log every 100 chunks
-    stream_start_time = None  # Track when we start receiving chunks
-
-    # notify ui of tokens
-    if task_id:
-        try:
-            input_chunk_content = ""
-            for msg in messages:
-                if "content" in msg and isinstance(msg["content"], str):
-                    input_chunk_content += msg["content"]
-                elif isinstance(msg["content"], list): # Handle list content (e.g. vision models)
-                    for item in msg["content"]:
-                        if isinstance(item, dict) and item.get("type") == "text":
-                            input_chunk_content += item.get("text", "")
-            input_token_estimate = token_encoder.encode(input_chunk_content)
-            app.ui.update_task_info(task_id, update={"input_token_estimate": len(input_token_estimate), "model": model})
-        except Exception as e:
-            app.logger.error(f"Error estimating input tokens: {e}")
-
-    output_tokens_estimate = 0
-    final_chunk_data = None
-    async for chunk in stream:
-        if first_chunk:
-            stream_start_time = time.time()
-            app.logger.info(f"Started receiving response from {model}")
-            first_chunk = False
-        chunk_count += 1
-        if chunk_count % log_interval == 0 and stream_start_time:
-            elapsed = time.time() - stream_start_time
-            app.logger.info(f"Received {chunk_count} chunks from {model} ({round(chunk_count/elapsed,2) if elapsed > 0 else 0} chunks/sec)")
-
-        if chunk.choices and chunk.choices[0].delta.content:
-            chunk_text = chunk.choices[0].delta.content
-            if task_id:
-                try:
-                    tokens = token_encoder.encode(chunk_text)
-                    output_tokens_estimate += len(tokens)
-                    if chunk_count % 10 == 0 and stream_start_time:
-                        elapsed = time.time() - stream_start_time
-                        app.ui.update_task_info(worker_id=task_id, update={"output_token_estimate": output_tokens_estimate, "tokens_per_second": (output_tokens_estimate)/elapsed if elapsed>0 else 0})
-                except Exception as e:
-                    app.logger.error(f"Error estimating output tokens for chunk: {e}")
-            yield chunk_text
-        final_chunk_data = chunk # Store the last chunk to access usage data if available
-
-    if final_chunk_data and hasattr(final_chunk_data, 'usage') and final_chunk_data.usage:
-        input_tokens = final_chunk_data.usage.prompt_tokens
-        output_tokens = final_chunk_data.usage.completion_tokens
-        end_time = time.time()
-        elapsed_seconds = round(end_time - start_time, 2)
-        stream_elapsed = end_time - (stream_start_time or start_time)
-        if task_id:
-            app.ui.update_task_info(worker_id=task_id, update={"input_tokens": input_tokens, "output_tokens": output_tokens, "tokens_per_second": round(output_tokens/stream_elapsed,2) if stream_elapsed > 0 else 0})
-        app.logger.info(f"Response completed: {model}, {input_tokens} input tokens, {output_tokens} output tokens, {elapsed_seconds}s, {chunk_count} chunks, {round(chunk_count/stream_elapsed,2) if stream_elapsed > 0 else 0} chunks/sec")
-        await get_instance().add_use(model, input_tokens, output_tokens)
-    elif stream_start_time: # Fallback if usage not in final chunk but stream happened
-        end_time = time.time()
-        elapsed_seconds = round(end_time - start_time, 2)
-        stream_elapsed = end_time - stream_start_time
-        app.logger.info(f"Response completed (no usage data in final chunk): {model}, {elapsed_seconds}s, {chunk_count} chunks, {round(chunk_count/stream_elapsed,2) if stream_elapsed > 0 else 0} chunks/sec")
-
-
-async def stream_messages_format(app, model, messages, task_id=None, print_stream=True) -> AsyncIterator[str]:
-    start_time = time.time()
-    context_files = []
-    for m in messages:
-        if isinstance(m.get("content"), str) and "Supporting Context" in m.get("content", ""):
-            for line in m["content"].split("\n"):
-                if "Context File" in line and ":" in line:
-                    try:
-                        context_files.append(line.split(":",1)[1].strip())
-                    except:
-                        pass
-    log_msg = f"Sending request to {model} with {len(messages)} messages"
-    if context_files:
-        log_msg += f", context files: {', '.join(context_files)}"
-    app.logger.info(log_msg)
-    client = app.state.clients.anthropic
-    if not client:
-        raise ValueError(f"Anthropic API key not configured but model {model} requires it")
-    anthropic_messages = []
-    system_message = None
-    for msg in messages:
-        if msg["role"] == "system":
-            system_message = msg["content"]
-    for msg in messages:
-        if msg["role"] in ("user","assistant"):
-            anthropic_messages.append({"role": msg["role"], "content": msg["content"]})
-    
-    chunk_count = 0
-    log_interval = 100
-    token_encoder = tiktoken.get_encoding("cl100k_base")
-    if task_id:
-        try:
-            inp_content = ""
-            for m in messages:
-                if isinstance(m.get("content"), str):
-                    inp_content += m.get("content","")
-                elif isinstance(m.get("content"), list):
-                     for item in m.get("content",[]):
-                        if isinstance(item, dict) and item.get("type") == "text":
-                            inp_content += item.get("text", "")
-            app.ui.update_task_info(task_id, update={"input_token_estimate": len(token_encoder.encode(inp_content)), "model": model})
-        except Exception as e:
-            app.logger.error(f"Error estimating input tokens for Anthropic: {e}")
-
-    try:
-        kwargs = {"model": model, "messages": anthropic_messages, "max_tokens": 8192, "temperature": 0.0}
-        if system_message is not None:
-            kwargs["system"] = system_message
-        stream_manager = client.messages.stream(**kwargs)
-        
-        app.logger.info(f"Started receiving response from {model}")
-        stream_start_time = time.time()
-        output_tokens_estimate = 0
-        final_output_tokens = 0
-        
-        async with stream_manager as stream:
-            async for chunk in stream:
-                if chunk.type == 'content_block_delta' and hasattr(chunk.delta,'text'):
-                    ct = chunk.delta.text
-                    if task_id:
-                        try:
-                            tokens = token_encoder.encode(ct)
-                            output_tokens_estimate += len(tokens)
-                            if chunk_count % 10 == 0 and output_tokens_estimate>0:
-                                elapsed = time.time() - stream_start_time
-                                app.ui.update_task_info(worker_id=task_id, update={"output_token_estimate": output_tokens_estimate, "tokens_per_second": (output_tokens_estimate)/elapsed if elapsed>0 else 0})
-                        except Exception as e:
-                            app.logger.error(f"Error estimating output tokens for Anthropic chunk: {e}")
-                    yield ct
-                elif chunk.type == 'message_delta' and hasattr(chunk,'usage') and hasattr(chunk.usage,'output_tokens'):
-                    final_output_tokens += chunk.usage.output_tokens # Accumulate final output tokens from delta
-                
-                chunk_count += 1
-                if chunk_count % log_interval == 0:
-                    elapsed = time.time() - stream_start_time
-                    app.logger.info(f"Received {chunk_count} chunks from {model} ({round(chunk_count/elapsed,2) if elapsed > 0 else 0} chunks/sec)")
-            
-            # After stream finishes, get final usage if available in the stream object itself
-            # (Anthropic's stream object might provide total usage at the end)
-            # For now, we rely on message_delta for output_tokens.
-            # Input tokens need to be calculated manually for Anthropic if not provided directly.
-            
-            input_tokens_content = ""
-            for m in messages:
-                if isinstance(m.get("content"), str):
-                    input_tokens_content += m.get("content","")
-                elif isinstance(m.get("content"), list):
-                    for item_content in m.get("content",[]):
-                        if isinstance(item_content, dict) and item_content.get("type") == "text":
-                            input_tokens_content += item_content.get("text", "")
-            if system_message:
-                 input_tokens_content += system_message
-
-            input_tokens = len(token_encoder.encode(input_tokens_content))
-            
-            # If final_output_tokens wasn't updated by message_delta, estimate from accumulated text (less accurate)
-            # This part is tricky as we don't accumulate response_text anymore.
-            # For now, we rely on final_output_tokens from message_delta.
-            # If that's zero, it means the SDK didn't provide it incrementally.
-            # The SDK docs should be checked for the best way to get final token counts.
-
-            end_time = time.time()
-            elapsed = round(end_time - start_time,2)
-            stream_elapsed = end_time - stream_start_time
-            
-            app.logger.info(f"Response completed: {model}, {input_tokens} input tokens, {final_output_tokens if final_output_tokens > 0 else 'N/A'} output tokens, {elapsed}s, {chunk_count} chunks, {round(chunk_count/stream_elapsed,2) if stream_elapsed > 0 else 0} chunks/sec")
-            if final_output_tokens > 0:
-                await get_instance().add_use(model, input_tokens, final_output_tokens)
-            if task_id:
-                app.ui.update_task_info(worker_id=task_id, update={"input_tokens": input_tokens, "output_tokens": final_output_tokens if final_output_tokens > 0 else output_tokens_estimate, "tokens_per_second": round((final_output_tokens if final_output_tokens > 0 else output_tokens_estimate)/stream_elapsed,2) if stream_elapsed > 0 else 0})
-
-    except Exception as e:
-        app.logger.error(f"Error making Anthropic API request: {str(e)}")
-        raise ValueError(f"Error making Anthropic API request: {str(e)}")
 
 def stream_request(app, model, messages, task_id=None, print_stream=True, json_output=False, max_output_tokens=None) -> AsyncIterator[str]:
+    """
+    Dispatches the streaming request to the appropriate provider streamer.
+    """
     model_provider = None
     for entry in app.get_models():
         if entry["name"] == model:
             model_provider = entry["provider"]
             break
+
     if model_provider == "anthropic":
-        return stream_messages_format(app, model, messages, task_id, print_stream)
+        streamer = AnthropicStreamer(app)
+        # Anthropic streamer doesn't use json_output or max_output_tokens in its signature
+        return streamer.stream(model, messages, task_id)
     else:
-        return stream_openai_format(app, model, messages, task_id, print_stream, json_output, max_output_tokens)
+        streamer = OpenAIStreamer(app)
+        return streamer.stream(
+            model,
+            messages,
+            task_id,
+            json_output=json_output,
+            max_output_tokens=max_output_tokens
+        )
+
 
 async def generate_llm_response(app, model, messages, task_id=None, print_stream=True, json_output=False, max_output_tokens=None, attempts=0):
     # Stream response from LLM and return the full response string

--- a/src/jrdev/services/provider_factory.py
+++ b/src/jrdev/services/provider_factory.py
@@ -1,0 +1,80 @@
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from jrdev.core.application import Application
+    from jrdev.models.api_provider import ApiProvider
+
+_app: Optional['Application'] = None
+
+
+def initialize_provider_factory(app: 'Application'):
+    """Initializes the provider factory with the application instance."""
+    global _app
+    _app = app
+
+
+def _get_app() -> 'Application':
+    """Returns the application instance, raising an error if not initialized."""
+    if _app is None:
+        raise RuntimeError("Provider factory has not been initialized. Call initialize_provider_factory() first.")
+    return _app
+
+
+def get_client(provider_name: str) -> Optional[Any]:
+    """
+    Gets the API client for a given provider name.
+
+    Args:
+        provider_name: The name of the provider.
+
+    Returns:
+        The initialized client instance, or None if not found or not initialized.
+    """
+    app = _get_app()
+    return app.state.clients.get_client(provider_name)
+
+
+def list_providers() -> List['ApiProvider']:
+    """
+    Lists all available API providers.
+
+    Returns:
+        A list of ApiProvider objects.
+    """
+    app = _get_app()
+    return app.state.clients.provider_list()
+
+
+def get_provider_for_model(model_name: str) -> Optional[str]:
+    """
+    Finds the provider name for a given model name.
+
+    Args:
+        model_name: The name of the model.
+
+    Returns:
+        The name of the provider, or None if the model is not found.
+    """
+    app = _get_app()
+    for model_info in app.get_models():
+        if model_info["name"] == model_name:
+            return model_info["provider"]
+    return None
+
+
+def add_provider(provider_data: Dict[str, Any]) -> None:
+    """Adds a new API provider."""
+    app = _get_app()
+    app.state.clients.add_provider(provider_data)
+
+
+def edit_provider(name: str, updated_fields: Dict[str, Any]) -> None:
+    """Edits an existing API provider."""
+    app = _get_app()
+    app.state.clients.edit_provider(name, updated_fields)
+
+
+def remove_provider(name: str) -> None:
+    """Removes an API provider."""
+    app = _get_app()
+    app.state.clients.remove_provider(name)

--- a/src/jrdev/services/request_wrapper.py
+++ b/src/jrdev/services/request_wrapper.py
@@ -1,0 +1,62 @@
+import asyncio
+from functools import wraps
+from typing import AsyncIterator, Callable, Any
+
+
+class RetryableStreamError(Exception):
+    """Raised when a stream fails and should be retried."""
+    pass
+
+
+def retry_stream(max_attempts: int = 2, backoff: float = 0.5):
+    """
+    Decorator that retries an async streaming function up to `max_attempts` times.
+    Only retries on RetryableStreamError or other non-CancelledError exceptions.
+    """
+    def decorator(func: Callable[..., AsyncIterator[str]]):
+        @wraps(func)
+        async def wrapper(*args, **kwargs) -> AsyncIterator[str]:
+            attempt = 0
+            while True:
+                try:
+                    async for chunk in func(*args, **kwargs):
+                        yield chunk
+                    return
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    attempt += 1
+                    if attempt >= max_attempts:
+                        raise
+                    await asyncio.sleep(backoff * (2 ** (attempt - 1)))
+        return wrapper
+    return decorator
+
+
+async def filter_think_tags(stream: AsyncIterator[str]) -> AsyncIterator[str]:
+    """
+    Middleware that filters out <think>...</think> blocks from an async string stream.
+    """
+    first_chunk = True
+    in_think = False
+    thinking_finish = False
+
+    async for chunk in stream:
+        if first_chunk:
+            first_chunk = False
+            if chunk == "<think>":
+                in_think = True
+                continue
+            else:
+                yield chunk
+        elif in_think:
+            if chunk == "</think>":
+                in_think = False
+                thinking_finish = True
+            continue
+        else:
+            if thinking_finish:
+                while chunk.startswith("\n"):
+                    chunk = chunk.removeprefix("\n")
+                thinking_finish = False
+            yield chunk

--- a/src/jrdev/services/streaming/anthropic_streamer.py
+++ b/src/jrdev/services/streaming/anthropic_streamer.py
@@ -1,8 +1,6 @@
 import time
-import tiktoken
 from typing import Any, AsyncIterator, Dict, List
 
-from jrdev.core.usage import get_instance
 from jrdev.services.streaming.base_streamer import BaseStreamer
 
 
@@ -29,6 +27,8 @@ class AnthropicStreamer(BaseStreamer):
             A string chunk of the response.
         """
         start_time = time.time()
+
+        # Provider-specific logging
         context_files = []
         for m in messages:
             if isinstance(m.get("content"), str) and "Supporting Context" in m.get("content", ""):
@@ -41,12 +41,14 @@ class AnthropicStreamer(BaseStreamer):
         log_msg = f"Sending request to {model} with {len(messages)} messages"
         if context_files:
             log_msg += f", context files: {', '.join(context_files)}"
-        self.app.logger.info(log_msg)
+        self.logger.info(log_msg)
 
+        # Provider-specific client setup
         client = self.app.state.clients.anthropic
         if not client:
             raise ValueError(f"Anthropic API key not configured but model {model} requires it")
 
+        # Provider-specific message formatting
         anthropic_messages = []
         system_message = None
         for msg in messages:
@@ -56,79 +58,55 @@ class AnthropicStreamer(BaseStreamer):
             if msg["role"] in ("user", "assistant"):
                 anthropic_messages.append({"role": msg["role"], "content": msg["content"]})
 
-        chunk_count = 0
-        log_interval = 100
-        token_encoder = tiktoken.get_encoding("cl100k_base")
-        if task_id:
-            try:
-                inp_content = ""
-                for m in messages:
-                    if isinstance(m.get("content"), str):
-                        inp_content += m.get("content", "")
-                    elif isinstance(m.get("content"), list):
-                        for item in m.get("content", []):
-                            if isinstance(item, dict) and item.get("type") == "text":
-                                inp_content += item.get("text", "")
-                self.app.ui.update_task_info(task_id, update={"input_token_estimate": len(token_encoder.encode(inp_content)), "model": model})
-            except Exception as e:
-                self.app.logger.error(f"Error estimating input tokens for Anthropic: {e}")
+        # Use shared helper for initial UI update
+        self._update_ui_initial(task_id, model, messages, system_message)
 
         try:
             request_kwargs = {"model": model, "messages": anthropic_messages, "max_tokens": 8192, "temperature": 0.0}
             if system_message is not None:
                 request_kwargs["system"] = system_message
+            
             stream_manager = client.messages.stream(**request_kwargs)
 
-            self.app.logger.info(f"Started receiving response from {model}")
-            stream_start_time = time.time()
+            # Initial setup for streaming
+            chunk_count = 0
             output_tokens_estimate = 0
+            stream_start_time = None
             final_output_tokens = 0
 
             async with stream_manager as stream:
                 async for chunk in stream:
+                    if stream_start_time is None:
+                        stream_start_time = time.time()
+                        self.logger.info(f"Started receiving response from {model}")
+
+                    chunk_count += 1
+                    self._log_chunk_progress(chunk_count, model, stream_start_time)
+
                     if chunk.type == 'content_block_delta' and hasattr(chunk.delta, 'text'):
-                        ct = chunk.delta.text
-                        if task_id:
-                            try:
-                                tokens = token_encoder.encode(ct)
-                                output_tokens_estimate += len(tokens)
-                                if chunk_count % 10 == 0 and output_tokens_estimate > 0:
-                                    elapsed = time.time() - stream_start_time
-                                    self.app.ui.update_task_info(worker_id=task_id, update={"output_token_estimate": output_tokens_estimate, "tokens_per_second": (output_tokens_estimate) / elapsed if elapsed > 0 else 0})
-                            except Exception as e:
-                                self.app.logger.error(f"Error estimating output tokens for Anthropic chunk: {e}")
-                        yield ct
+                        chunk_text = chunk.delta.text
+                        # Use shared helper for streaming UI update
+                        output_tokens_estimate = self._update_ui_streaming(
+                            task_id, chunk_text, chunk_count, output_tokens_estimate, stream_start_time
+                        )
+                        yield chunk_text
                     elif chunk.type == 'message_delta' and hasattr(chunk, 'usage') and hasattr(chunk.usage, 'output_tokens'):
                         final_output_tokens += chunk.usage.output_tokens  # Accumulate final output tokens from delta
 
-                    chunk_count += 1
-                    if chunk_count % log_interval == 0 and stream_start_time:
-                        elapsed = time.time() - stream_start_time
-                        self.app.logger.info(f"Received {chunk_count} chunks from {model} ({round(chunk_count / elapsed, 2) if elapsed > 0 else 0} chunks/sec)")
-
-            input_tokens_content = ""
-            for m in messages:
-                if isinstance(m.get("content"), str):
-                    input_tokens_content += m.get("content", "")
-                elif isinstance(m.get("content"), list):
-                    for item_content in m.get("content", []):
-                        if isinstance(item_content, dict) and item_content.get("type") == "text":
-                            input_tokens_content += item_content.get("text", "")
-            if system_message:
-                input_tokens_content += system_message
-
-            input_tokens = len(token_encoder.encode(input_tokens_content))
-
-            end_time = time.time()
-            elapsed = round(end_time - start_time, 2)
-            stream_elapsed = end_time - stream_start_time
-
-            self.app.logger.info(f"Response completed: {model}, {input_tokens} input tokens, {final_output_tokens if final_output_tokens > 0 else 'N/A'} output tokens, {elapsed}s, {chunk_count} chunks, {round(chunk_count / stream_elapsed, 2) if stream_elapsed > 0 else 0} chunks/sec")
-            if final_output_tokens > 0:
-                await get_instance().add_use(model, input_tokens, final_output_tokens)
-            if task_id:
-                self.app.ui.update_task_info(worker_id=task_id, update={"input_tokens": input_tokens, "output_tokens": final_output_tokens if final_output_tokens > 0 else output_tokens_estimate, "tokens_per_second": round((final_output_tokens if final_output_tokens > 0 else output_tokens_estimate) / stream_elapsed, 2) if stream_elapsed > 0 else 0})
+            # Finalize and log using shared helper
+            input_tokens = self._estimate_input_tokens(messages, system_message)
+            
+            await self._finalize_stream(
+                task_id=task_id,
+                model=model,
+                chunk_count=chunk_count,
+                start_time=start_time,
+                stream_start_time=stream_start_time,
+                input_tokens=input_tokens,
+                output_tokens=final_output_tokens,
+                output_token_estimate=output_tokens_estimate
+            )
 
         except Exception as e:
-            self.app.logger.error(f"Error making Anthropic API request: {str(e)}")
+            self.logger.error(f"Error making Anthropic API request: {str(e)}")
             raise ValueError(f"Error making Anthropic API request: {str(e)}")

--- a/src/jrdev/services/streaming/anthropic_streamer.py
+++ b/src/jrdev/services/streaming/anthropic_streamer.py
@@ -1,0 +1,134 @@
+import time
+import tiktoken
+from typing import Any, AsyncIterator, Dict, List
+
+from jrdev.core.usage import get_instance
+from jrdev.services.streaming.base_streamer import BaseStreamer
+
+
+class AnthropicStreamer(BaseStreamer):
+    """Streamer for Anthropic API."""
+
+    async def stream(
+        self,
+        model: str,
+        messages: List[Dict[str, Any]],
+        task_id: str = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[str]:
+        """
+        Streams a response from an Anthropic language model.
+
+        Args:
+            model: The name of the model to use.
+            messages: A list of message dictionaries in OpenAI format.
+            task_id: The optional ID of the task for UI updates.
+            **kwargs: Additional arguments (not used for Anthropic).
+
+        Yields:
+            A string chunk of the response.
+        """
+        start_time = time.time()
+        context_files = []
+        for m in messages:
+            if isinstance(m.get("content"), str) and "Supporting Context" in m.get("content", ""):
+                for line in m["content"].split("\n"):
+                    if "Context File" in line and ":" in line:
+                        try:
+                            context_files.append(line.split(":", 1)[1].strip())
+                        except:
+                            pass
+        log_msg = f"Sending request to {model} with {len(messages)} messages"
+        if context_files:
+            log_msg += f", context files: {', '.join(context_files)}"
+        self.app.logger.info(log_msg)
+
+        client = self.app.state.clients.anthropic
+        if not client:
+            raise ValueError(f"Anthropic API key not configured but model {model} requires it")
+
+        anthropic_messages = []
+        system_message = None
+        for msg in messages:
+            if msg["role"] == "system":
+                system_message = msg["content"]
+        for msg in messages:
+            if msg["role"] in ("user", "assistant"):
+                anthropic_messages.append({"role": msg["role"], "content": msg["content"]})
+
+        chunk_count = 0
+        log_interval = 100
+        token_encoder = tiktoken.get_encoding("cl100k_base")
+        if task_id:
+            try:
+                inp_content = ""
+                for m in messages:
+                    if isinstance(m.get("content"), str):
+                        inp_content += m.get("content", "")
+                    elif isinstance(m.get("content"), list):
+                        for item in m.get("content", []):
+                            if isinstance(item, dict) and item.get("type") == "text":
+                                inp_content += item.get("text", "")
+                self.app.ui.update_task_info(task_id, update={"input_token_estimate": len(token_encoder.encode(inp_content)), "model": model})
+            except Exception as e:
+                self.app.logger.error(f"Error estimating input tokens for Anthropic: {e}")
+
+        try:
+            request_kwargs = {"model": model, "messages": anthropic_messages, "max_tokens": 8192, "temperature": 0.0}
+            if system_message is not None:
+                request_kwargs["system"] = system_message
+            stream_manager = client.messages.stream(**request_kwargs)
+
+            self.app.logger.info(f"Started receiving response from {model}")
+            stream_start_time = time.time()
+            output_tokens_estimate = 0
+            final_output_tokens = 0
+
+            async with stream_manager as stream:
+                async for chunk in stream:
+                    if chunk.type == 'content_block_delta' and hasattr(chunk.delta, 'text'):
+                        ct = chunk.delta.text
+                        if task_id:
+                            try:
+                                tokens = token_encoder.encode(ct)
+                                output_tokens_estimate += len(tokens)
+                                if chunk_count % 10 == 0 and output_tokens_estimate > 0:
+                                    elapsed = time.time() - stream_start_time
+                                    self.app.ui.update_task_info(worker_id=task_id, update={"output_token_estimate": output_tokens_estimate, "tokens_per_second": (output_tokens_estimate) / elapsed if elapsed > 0 else 0})
+                            except Exception as e:
+                                self.app.logger.error(f"Error estimating output tokens for Anthropic chunk: {e}")
+                        yield ct
+                    elif chunk.type == 'message_delta' and hasattr(chunk, 'usage') and hasattr(chunk.usage, 'output_tokens'):
+                        final_output_tokens += chunk.usage.output_tokens  # Accumulate final output tokens from delta
+
+                    chunk_count += 1
+                    if chunk_count % log_interval == 0 and stream_start_time:
+                        elapsed = time.time() - stream_start_time
+                        self.app.logger.info(f"Received {chunk_count} chunks from {model} ({round(chunk_count / elapsed, 2) if elapsed > 0 else 0} chunks/sec)")
+
+            input_tokens_content = ""
+            for m in messages:
+                if isinstance(m.get("content"), str):
+                    input_tokens_content += m.get("content", "")
+                elif isinstance(m.get("content"), list):
+                    for item_content in m.get("content", []):
+                        if isinstance(item_content, dict) and item_content.get("type") == "text":
+                            input_tokens_content += item_content.get("text", "")
+            if system_message:
+                input_tokens_content += system_message
+
+            input_tokens = len(token_encoder.encode(input_tokens_content))
+
+            end_time = time.time()
+            elapsed = round(end_time - start_time, 2)
+            stream_elapsed = end_time - stream_start_time
+
+            self.app.logger.info(f"Response completed: {model}, {input_tokens} input tokens, {final_output_tokens if final_output_tokens > 0 else 'N/A'} output tokens, {elapsed}s, {chunk_count} chunks, {round(chunk_count / stream_elapsed, 2) if stream_elapsed > 0 else 0} chunks/sec")
+            if final_output_tokens > 0:
+                await get_instance().add_use(model, input_tokens, final_output_tokens)
+            if task_id:
+                self.app.ui.update_task_info(worker_id=task_id, update={"input_tokens": input_tokens, "output_tokens": final_output_tokens if final_output_tokens > 0 else output_tokens_estimate, "tokens_per_second": round((final_output_tokens if final_output_tokens > 0 else output_tokens_estimate) / stream_elapsed, 2) if stream_elapsed > 0 else 0})
+
+        except Exception as e:
+            self.app.logger.error(f"Error making Anthropic API request: {str(e)}")
+            raise ValueError(f"Error making Anthropic API request: {str(e)}")

--- a/src/jrdev/services/streaming/anthropic_streamer.py
+++ b/src/jrdev/services/streaming/anthropic_streamer.py
@@ -1,11 +1,15 @@
 import time
 from typing import Any, AsyncIterator, Dict, List
 
+from jrdev.services import provider_factory
 from jrdev.services.streaming.base_streamer import BaseStreamer
 
 
 class AnthropicStreamer(BaseStreamer):
     """Streamer for Anthropic API."""
+
+    def __init__(self, logger: Any, ui: Any, usageTracker: Any):
+        super().__init__(logger, ui, usageTracker)
 
     async def stream(
         self,
@@ -44,7 +48,7 @@ class AnthropicStreamer(BaseStreamer):
         self.logger.info(log_msg)
 
         # Provider-specific client setup
-        client = self.app.state.clients.anthropic
+        client = provider_factory.get_client("anthropic")
         if not client:
             raise ValueError(f"Anthropic API key not configured but model {model} requires it")
 

--- a/src/jrdev/services/streaming/base_streamer.py
+++ b/src/jrdev/services/streaming/base_streamer.py
@@ -1,5 +1,10 @@
 from abc import ABC, abstractmethod
+import time
 from typing import Any, AsyncIterator, Dict, List
+
+import tiktoken
+
+from jrdev.core.usage import get_instance
 
 
 class BaseStreamer(ABC):
@@ -8,6 +13,106 @@ class BaseStreamer(ABC):
     def __init__(self, app: Any):
         self.app = app
         self.logger = app.logger
+        self.token_encoder = tiktoken.get_encoding("cl100k_base")
+        self.log_interval = 100
+        self.ui_update_interval = 10
+
+    def _estimate_input_tokens(self, messages: List[Dict[str, Any]], system_message: str = None) -> int:
+        """Estimates the number of input tokens for a list of messages."""
+        content = ""
+        for msg in messages:
+            if isinstance(msg.get("content"), str):
+                content += msg["content"]
+            elif isinstance(msg.get("content"), list):
+                for item in msg["content"]:
+                    if isinstance(item, dict) and item.get("type") == "text":
+                        content += item.get("text", "")
+        if system_message:
+            content += system_message
+        return len(self.token_encoder.encode(content))
+
+    def _update_ui_initial(self, task_id: str, model: str, messages: List[Dict[str, Any]], system_message: str = None):
+        """Updates the UI with initial token estimates."""
+        if not task_id:
+            return
+        try:
+            input_token_estimate = self._estimate_input_tokens(messages, system_message)
+            self.app.ui.update_task_info(task_id, update={"input_token_estimate": input_token_estimate, "model": model})
+        except Exception as e:
+            self.logger.error(f"Error estimating input tokens: {e}")
+
+    def _log_chunk_progress(self, chunk_count: int, model: str, stream_start_time: float):
+        """Logs the progress of receiving chunks from the stream."""
+        if chunk_count > 0 and stream_start_time and chunk_count % self.log_interval == 0:
+            elapsed = time.time() - stream_start_time
+            chunks_per_sec = round(chunk_count / elapsed, 2) if elapsed > 0 else 0
+            self.logger.info(f"Received {chunk_count} chunks from {model} ({chunks_per_sec} chunks/sec)")
+
+    def _update_ui_streaming(self, task_id: str, chunk_text: str, chunk_count: int, output_tokens_estimate: int, stream_start_time: float) -> int:
+        """Updates the UI with streaming progress (token count, TPS)."""
+        if not task_id or not stream_start_time:
+            return output_tokens_estimate
+        try:
+            tokens = self.token_encoder.encode(chunk_text)
+            output_tokens_estimate += len(tokens)
+            if chunk_count > 0 and chunk_count % self.ui_update_interval == 0:
+                elapsed = time.time() - stream_start_time
+                tps = (output_tokens_estimate / elapsed) if elapsed > 0 else 0
+                self.app.ui.update_task_info(
+                    worker_id=task_id,
+                    update={"output_token_estimate": output_tokens_estimate, "tokens_per_second": tps}
+                )
+        except Exception as e:
+            self.logger.error(f"Error estimating output tokens for chunk: {e}")
+        return output_tokens_estimate
+
+    async def _finalize_stream(
+        self,
+        task_id: str,
+        model: str,
+        chunk_count: int,
+        start_time: float,
+        stream_start_time: float,
+        input_tokens: int,
+        output_tokens: int,
+        output_token_estimate: int
+    ):
+        """Finalizes the stream, logging stats and updating usage."""
+        if not stream_start_time: # Stream never started, probably an error before that
+            self.logger.warning(f"Stream for {model} did not start. Finalization skipped.")
+            return
+
+        end_time = time.time()
+        elapsed_seconds = round(end_time - start_time, 2)
+        stream_elapsed = end_time - stream_start_time
+        chunks_per_sec = round(chunk_count / stream_elapsed, 2) if stream_elapsed > 0 else 0
+
+        final_output_tokens = output_tokens if output_tokens > 0 else output_token_estimate
+        
+        if output_tokens > 0:
+            log_output_tokens_str = str(output_tokens)
+        else:
+            log_output_tokens_str = f"N/A (estimated {output_token_estimate})"
+
+        self.logger.info(
+            f"Response completed: {model}, {input_tokens} input tokens, "
+            f"{log_output_tokens_str} output tokens, {elapsed_seconds}s, "
+            f"{chunk_count} chunks, {chunks_per_sec} chunks/sec"
+        )
+
+        if output_tokens > 0:
+            await get_instance().add_use(model, input_tokens, output_tokens)
+
+        if task_id:
+            tps = round(final_output_tokens / stream_elapsed, 2) if stream_elapsed > 0 else 0
+            self.app.ui.update_task_info(
+                worker_id=task_id,
+                update={
+                    "input_tokens": input_tokens,
+                    "output_tokens": final_output_tokens,
+                    "tokens_per_second": tps
+                }
+            )
 
     @abstractmethod
     async def stream(

--- a/src/jrdev/services/streaming/base_streamer.py
+++ b/src/jrdev/services/streaming/base_streamer.py
@@ -1,0 +1,36 @@
+from abc import ABC, abstractmethod
+from typing import Any, AsyncIterator, Dict, List
+
+
+class BaseStreamer(ABC):
+    """Abstract base class for LLM provider streamers."""
+
+    def __init__(self, app: Any):
+        self.app = app
+        self.logger = app.logger
+
+    @abstractmethod
+    async def stream(
+        self,
+        model: str,
+        messages: List[Dict[str, Any]],
+        task_id: str = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[str]:
+        """
+        Streams a response from the language model.
+
+        Args:
+            model: The name of the model to use.
+            messages: A list of message dictionaries, OpenAI format.
+            task_id: The optional ID of the task for UI updates.
+            **kwargs: Additional provider-specific arguments.
+
+        Yields:
+            A string chunk of the response.
+        """
+        # This is an abstract method, so it should not have a real implementation.
+        # The `yield` statement is here to make this an async generator function.
+        # It will never be executed.
+        if False:
+            yield

--- a/src/jrdev/services/streaming/openai_streamer.py
+++ b/src/jrdev/services/streaming/openai_streamer.py
@@ -1,0 +1,153 @@
+import time
+import tiktoken
+from typing import Any, AsyncIterator, Dict, List
+
+from jrdev.core.usage import get_instance
+from jrdev.services.streaming.base_streamer import BaseStreamer
+
+
+class OpenAIStreamer(BaseStreamer):
+    """Streamer for OpenAI-compatible API providers."""
+
+    async def stream(
+        self,
+        model: str,
+        messages: List[Dict[str, Any]],
+        task_id: str = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[str]:
+        """
+        Streams a response from an OpenAI-compatible language model.
+
+        Args:
+            model: The name of the model to use.
+            messages: A list of message dictionaries in OpenAI format.
+            task_id: The optional ID of the task for UI updates.
+            **kwargs: Additional arguments. Expected: 'json_output', 'max_output_tokens'.
+
+        Yields:
+            A string chunk of the response.
+        """
+        json_output = kwargs.get("json_output", False)
+        max_output_tokens = kwargs.get("max_output_tokens")
+
+        # Start timing the response
+        start_time = time.time()
+
+        log_msg = f"Sending request to {model} with {len(messages)} messages"
+        self.app.logger.info(log_msg)
+
+        # Get the appropriate client
+        model_provider = None
+
+        # Find the model in AVAILABLE_MODELS
+        available_models = self.app.get_models()
+        for entry in available_models:
+            if entry["name"] == model:
+                model_provider = entry["provider"]
+                break
+
+        # token estimator
+        token_encoder = tiktoken.get_encoding("cl100k_base")
+
+        # Select the appropriate client based on provider
+        if model_provider not in self.app.state.clients.get_all_clients():
+            raise ValueError(f"No client for {model_provider}")
+        client = self.app.state.clients.get_client(model_provider)
+
+        # Create a streaming completion
+        request_kwargs = {
+            "model": model,
+            "messages": messages,
+            "stream": True,
+            "temperature": 0.0,
+            "extra_headers": {
+                "HTTP-Referer": "https://github.com/presstab/jrdev",
+                "X-Title": "JrDev"
+            }
+        }
+
+        if max_output_tokens:
+            request_kwargs["max_completion_tokens"] = max_output_tokens
+
+        if model_provider == "openai":
+            if "o3" in model or "o4-mini" in model:
+                request_kwargs["reasoning_effort"] = "high"
+                del request_kwargs["temperature"]
+            request_kwargs["stream_options"] = {"include_usage": True}
+        elif model == "qwen-2.5-qwq-32b":
+            request_kwargs["top_p"] = 0.95
+            request_kwargs["extra_body"] = {"venice_parameters": {"include_venice_system_prompt": False}, "frequency_penalty": 0.3}
+        elif model == "deepseek-r1-671b":
+            request_kwargs["extra_body"] = {"venice_parameters": {"include_venice_system_prompt": False}}
+        elif model == "deepseek-reasoner" or model == "deepseek-chat":
+            request_kwargs["max_tokens"] = 8000
+            if model == "deepseek-chat" and json_output:
+                request_kwargs["response_format"] = {"type": "json_object"}
+        elif model_provider == "venice":
+            request_kwargs["extra_body"] = {"venice_parameters": {"include_venice_system_prompt": False}}
+
+        stream = await client.chat.completions.create(**request_kwargs)
+
+        first_chunk = True
+        chunk_count = 0
+        log_interval = 100  # Log every 100 chunks
+        stream_start_time = None  # Track when we start receiving chunks
+
+        # notify ui of tokens
+        if task_id:
+            try:
+                input_chunk_content = ""
+                for msg in messages:
+                    if "content" in msg and isinstance(msg["content"], str):
+                        input_chunk_content += msg["content"]
+                    elif isinstance(msg["content"], list): # Handle list content (e.g. vision models)
+                        for item in msg["content"]:
+                            if isinstance(item, dict) and item.get("type") == "text":
+                                input_chunk_content += item.get("text", "")
+                input_token_estimate = token_encoder.encode(input_chunk_content)
+                self.app.ui.update_task_info(task_id, update={"input_token_estimate": len(input_token_estimate), "model": model})
+            except Exception as e:
+                self.app.logger.error(f"Error estimating input tokens: {e}")
+
+        output_tokens_estimate = 0
+        final_chunk_data = None
+        async for chunk in stream:
+            if first_chunk:
+                stream_start_time = time.time()
+                self.app.logger.info(f"Started receiving response from {model}")
+                first_chunk = False
+            chunk_count += 1
+            if chunk_count % log_interval == 0 and stream_start_time:
+                elapsed = time.time() - stream_start_time
+                self.app.logger.info(f"Received {chunk_count} chunks from {model} ({round(chunk_count/elapsed,2) if elapsed > 0 else 0} chunks/sec)")
+
+            if chunk.choices and chunk.choices[0].delta.content:
+                chunk_text = chunk.choices[0].delta.content
+                if task_id:
+                    try:
+                        tokens = token_encoder.encode(chunk_text)
+                        output_tokens_estimate += len(tokens)
+                        if chunk_count % 10 == 0 and stream_start_time:
+                            elapsed = time.time() - stream_start_time
+                            self.app.ui.update_task_info(worker_id=task_id, update={"output_token_estimate": output_tokens_estimate, "tokens_per_second": (output_tokens_estimate)/elapsed if elapsed>0 else 0})
+                    except Exception as e:
+                        self.app.logger.error(f"Error estimating output tokens for chunk: {e}")
+                yield chunk_text
+            final_chunk_data = chunk # Store the last chunk to access usage data if available
+
+        if final_chunk_data and hasattr(final_chunk_data, 'usage') and final_chunk_data.usage:
+            input_tokens = final_chunk_data.usage.prompt_tokens
+            output_tokens = final_chunk_data.usage.completion_tokens
+            end_time = time.time()
+            elapsed_seconds = round(end_time - start_time, 2)
+            stream_elapsed = end_time - (stream_start_time or start_time)
+            if task_id:
+                self.app.ui.update_task_info(worker_id=task_id, update={"input_tokens": input_tokens, "output_tokens": output_tokens, "tokens_per_second": round(output_tokens/stream_elapsed,2) if stream_elapsed > 0 else 0})
+            self.app.logger.info(f"Response completed: {model}, {input_tokens} input tokens, {output_tokens} output tokens, {elapsed_seconds}s, {chunk_count} chunks, {round(chunk_count/stream_elapsed,2) if stream_elapsed > 0 else 0} chunks/sec")
+            await get_instance().add_use(model, input_tokens, output_tokens)
+        elif stream_start_time: # Fallback if usage not in final chunk but stream happened
+            end_time = time.time()
+            elapsed_seconds = round(end_time - start_time, 2)
+            stream_elapsed = end_time - stream_start_time
+            self.app.logger.info(f"Response completed (no usage data in final chunk): {model}, {elapsed_seconds}s, {chunk_count} chunks, {round(chunk_count/stream_elapsed,2) if stream_elapsed > 0 else 0} chunks/sec")

--- a/src/jrdev/services/streaming/openai_streamer.py
+++ b/src/jrdev/services/streaming/openai_streamer.py
@@ -1,8 +1,6 @@
 import time
-import tiktoken
 from typing import Any, AsyncIterator, Dict, List
 
-from jrdev.core.usage import get_instance
 from jrdev.services.streaming.base_streamer import BaseStreamer
 
 
@@ -31,26 +29,18 @@ class OpenAIStreamer(BaseStreamer):
         json_output = kwargs.get("json_output", False)
         max_output_tokens = kwargs.get("max_output_tokens")
 
-        # Start timing the response
         start_time = time.time()
 
-        log_msg = f"Sending request to {model} with {len(messages)} messages"
-        self.app.logger.info(log_msg)
+        self.logger.info(f"Sending request to {model} with {len(messages)} messages")
 
         # Get the appropriate client
         model_provider = None
-
-        # Find the model in AVAILABLE_MODELS
         available_models = self.app.get_models()
         for entry in available_models:
             if entry["name"] == model:
                 model_provider = entry["provider"]
                 break
 
-        # token estimator
-        token_encoder = tiktoken.get_encoding("cl100k_base")
-
-        # Select the appropriate client based on provider
         if model_provider not in self.app.state.clients.get_all_clients():
             raise ValueError(f"No client for {model_provider}")
         client = self.app.state.clients.get_client(model_provider)
@@ -89,65 +79,48 @@ class OpenAIStreamer(BaseStreamer):
 
         stream = await client.chat.completions.create(**request_kwargs)
 
-        first_chunk = True
+        # Initial setup for streaming
         chunk_count = 0
-        log_interval = 100  # Log every 100 chunks
-        stream_start_time = None  # Track when we start receiving chunks
-
-        # notify ui of tokens
-        if task_id:
-            try:
-                input_chunk_content = ""
-                for msg in messages:
-                    if "content" in msg and isinstance(msg["content"], str):
-                        input_chunk_content += msg["content"]
-                    elif isinstance(msg["content"], list): # Handle list content (e.g. vision models)
-                        for item in msg["content"]:
-                            if isinstance(item, dict) and item.get("type") == "text":
-                                input_chunk_content += item.get("text", "")
-                input_token_estimate = token_encoder.encode(input_chunk_content)
-                self.app.ui.update_task_info(task_id, update={"input_token_estimate": len(input_token_estimate), "model": model})
-            except Exception as e:
-                self.app.logger.error(f"Error estimating input tokens: {e}")
-
         output_tokens_estimate = 0
+        stream_start_time = None
         final_chunk_data = None
+
+        self._update_ui_initial(task_id, model, messages)
+
         async for chunk in stream:
-            if first_chunk:
+            if stream_start_time is None:
                 stream_start_time = time.time()
-                self.app.logger.info(f"Started receiving response from {model}")
-                first_chunk = False
+                self.logger.info(f"Started receiving response from {model}")
+
             chunk_count += 1
-            if chunk_count % log_interval == 0 and stream_start_time:
-                elapsed = time.time() - stream_start_time
-                self.app.logger.info(f"Received {chunk_count} chunks from {model} ({round(chunk_count/elapsed,2) if elapsed > 0 else 0} chunks/sec)")
+            self._log_chunk_progress(chunk_count, model, stream_start_time)
 
             if chunk.choices and chunk.choices[0].delta.content:
                 chunk_text = chunk.choices[0].delta.content
-                if task_id:
-                    try:
-                        tokens = token_encoder.encode(chunk_text)
-                        output_tokens_estimate += len(tokens)
-                        if chunk_count % 10 == 0 and stream_start_time:
-                            elapsed = time.time() - stream_start_time
-                            self.app.ui.update_task_info(worker_id=task_id, update={"output_token_estimate": output_tokens_estimate, "tokens_per_second": (output_tokens_estimate)/elapsed if elapsed>0 else 0})
-                    except Exception as e:
-                        self.app.logger.error(f"Error estimating output tokens for chunk: {e}")
+                output_tokens_estimate = self._update_ui_streaming(
+                    task_id, chunk_text, chunk_count, output_tokens_estimate, stream_start_time
+                )
                 yield chunk_text
-            final_chunk_data = chunk # Store the last chunk to access usage data if available
+            
+            final_chunk_data = chunk  # Store the last chunk to access usage data
 
+        # Finalize and log
+        input_tokens = 0
+        output_tokens = 0
         if final_chunk_data and hasattr(final_chunk_data, 'usage') and final_chunk_data.usage:
             input_tokens = final_chunk_data.usage.prompt_tokens
             output_tokens = final_chunk_data.usage.completion_tokens
-            end_time = time.time()
-            elapsed_seconds = round(end_time - start_time, 2)
-            stream_elapsed = end_time - (stream_start_time or start_time)
-            if task_id:
-                self.app.ui.update_task_info(worker_id=task_id, update={"input_tokens": input_tokens, "output_tokens": output_tokens, "tokens_per_second": round(output_tokens/stream_elapsed,2) if stream_elapsed > 0 else 0})
-            self.app.logger.info(f"Response completed: {model}, {input_tokens} input tokens, {output_tokens} output tokens, {elapsed_seconds}s, {chunk_count} chunks, {round(chunk_count/stream_elapsed,2) if stream_elapsed > 0 else 0} chunks/sec")
-            await get_instance().add_use(model, input_tokens, output_tokens)
-        elif stream_start_time: # Fallback if usage not in final chunk but stream happened
-            end_time = time.time()
-            elapsed_seconds = round(end_time - start_time, 2)
-            stream_elapsed = end_time - stream_start_time
-            self.app.logger.info(f"Response completed (no usage data in final chunk): {model}, {elapsed_seconds}s, {chunk_count} chunks, {round(chunk_count/stream_elapsed,2) if stream_elapsed > 0 else 0} chunks/sec")
+        else:
+            # Fallback to estimation if usage data is not available
+            input_tokens = self._estimate_input_tokens(messages)
+
+        await self._finalize_stream(
+            task_id=task_id,
+            model=model,
+            chunk_count=chunk_count,
+            start_time=start_time,
+            stream_start_time=stream_start_time,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            output_token_estimate=output_tokens_estimate
+        )


### PR DESCRIPTION
### Refactor LLM Streaming and Provider Management for Enhanced Modularity

#### Overview
This pull request introduces a modular architecture for handling LLM requests and streaming responses, separating concerns into a provider factory and dedicated streamer classes for different API providers. These changes address the need for better code organization, easier extensibility when adding new providers, and improved reliability through retry mechanisms and consistent token tracking. By centralizing provider management and abstracting streaming logic, the codebase becomes more maintainable while preserving existing functionality for commands, usage tracking, and user interactions.

#### What This Means for Users
End-users will benefit from more robust LLM interactions, as the new retry logic automatically handles transient errors during streaming requests, reducing the likelihood of failed responses. In the terminal UI, a new keybinding (Shift+PageDown) enables inserting newlines directly in the input widget, making it simpler to format multi-line commands or messages without relying on external editors.

#### A Closer Look at the Changes
The updates focus on refactoring core LLM and provider logic to promote separation of concerns, while incorporating minor enhancements for usability and reliability. Related changes are grouped to highlight how they contribute to a more cohesive system.

- **Code Refinements & Improvements**:
  - Extracted LLM streaming logic from `llm_requests.py` into a new `streaming` submodule with an abstract base class (`base_streamer.py`) that defines shared behaviors like token estimation, UI updates, and logging. This abstraction ensures consistent handling across providers, reducing duplication and improving readability.
  - Introduced a retry decorator in `request_wrapper.py` to automatically reattempt failed streaming requests up to two times with exponential backoff, enhancing resilience without altering the calling code.
  - Added a filtering mechanism in `request_wrapper.py` to remove `<think>` tags from streamed responses, ensuring cleaner output without manual post-processing.
  - Renamed the usage tracker getter from `get_instance` to `get_token_tracker_instance` in `usage.py` and related files, providing clearer naming and initializing it directly in the application class for better encapsulation.
  - Updated the router prompt in `select_command.md` to refine guidelines for command selection, emphasizing appropriate use of the `/code` command and preferring tool-based answers for questions, which leads to more efficient agent behavior.

- **New Functionality**:
  - Added `provider_factory.py` to manage API providers centrally, including methods for listing, adding, editing, and removing providers. This factory is initialized with the application instance and replaces direct accesses to `app.state.clients`, decoupling provider operations from the main application state.
  - Implemented provider-specific streamers: `anthropic_streamer.py` for Anthropic models and `openai_streamer.py` for OpenAI-compatible providers. These handle request formatting, streaming, and usage tracking tailored to each provider's API, while leveraging the base streamer's shared utilities for token counting and UI integration.
  - Integrated the provider factory into commands and application logic, such as in `provider.py` for handling provider operations and in `application.py` for model availability checks, ensuring seamless access to clients without redundant code.
  - Added a new keybinding in `input_widget.py` for inserting newlines, addressing a common need for multi-line input in the TUI.

- **Bug Fixes**:
  - No explicit bug fixes were included, but the refactoring resolves potential issues with inconsistent streaming behavior across providers by standardizing the process and adding error handling.

These refinements collectively streamline the handling of LLM interactions, making it easier to support additional providers in the future while maintaining performance and user-facing stability. The addition to `.gitignore` prevents temporary `runs/` directories from being tracked, keeping repositories cleaner.
`Generated by JrDev AI using x-ai/grok-4`