### PR TITLE
Add provider model fetching and import workflow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyreadline3; platform_system=='Windows'
 windows-curses; platform_system=='Windows'
 colorama; platform_system=='Windows'
 pydantic>=2.0.0
+httpx

--- a/src/jrdev/agents/router_agent.py
+++ b/src/jrdev/agents/router_agent.py
@@ -119,6 +119,10 @@ class CommandInterpretationAgent:
 
         if decision == "execute_action":
             action = response_json.get("action")
+            if not action:
+                self.logger.error(f"Router decision was 'execute_action' but no action was provided. Response: {response_json}")
+                self.app.ui.print_text("I decided to execute an action, but encountered an error. Please try again.", print_type=PrintType.ERROR)
+                return None
             action_type = action.get("type")
             final_command = bool(response_json.get("final_command", False))
             reasoning = response_json.get("reasoning", "")

--- a/src/jrdev/core/application.py
+++ b/src/jrdev/core/application.py
@@ -28,6 +28,7 @@ from jrdev.models.model_profiles import ModelProfileManager
 from jrdev.models.model_utils import load_models, save_models
 from jrdev.services.contextmanager import ContextManager
 from jrdev.services.message_service import MessageService
+from jrdev.services.fetch_models_service import ModelFetchService
 from jrdev.ui.ui import PrintType
 from jrdev.ui.ui_wrapper import UiWrapper
 from jrdev.utils.treechart import generate_compact_tree
@@ -270,6 +271,7 @@ class Application:
             await self._initialize_api_clients()
 
         self.message_service = MessageService(self)
+        self.model_fetch_service = ModelFetchService()
 
         # Initialize the router agent
         self.router_agent = CommandInterpretationAgent(self)

--- a/src/jrdev/services/fetch_models_service.py
+++ b/src/jrdev/services/fetch_models_service.py
@@ -1,7 +1,13 @@
 from jrdev.services.providers.open_router import fetch_open_router_models
+from jrdev.services.providers.openai import fetch_open_ai_models
+
+from typing import Any
+
 
 class ModelFetchService:
-    async def fetch_provider_models(self, provider_name: str):
+    async def fetch_provider_models(self, provider_name: str, core_app: Any):
         if provider_name == "open_router":
             return await fetch_open_router_models()
+        elif provider_name == "openai":
+            return await fetch_open_ai_models(core_app)
         return None

--- a/src/jrdev/services/fetch_models_service.py
+++ b/src/jrdev/services/fetch_models_service.py
@@ -1,3 +1,4 @@
+from jrdev.services.providers.anthropic import fetch_open_anthropic_models
 from jrdev.services.providers.open_router import fetch_open_router_models
 from jrdev.services.providers.openai import fetch_open_ai_models
 
@@ -10,4 +11,6 @@ class ModelFetchService:
             return await fetch_open_router_models()
         elif provider_name == "openai":
             return await fetch_open_ai_models(core_app)
+        elif provider_name == "anthropic":
+            return await fetch_open_anthropic_models(core_app)
         return None

--- a/src/jrdev/services/fetch_models_service.py
+++ b/src/jrdev/services/fetch_models_service.py
@@ -1,6 +1,6 @@
 from jrdev.services.providers.anthropic import fetch_open_anthropic_models
+from jrdev.services.providers.generic_openai import fetch_openai_generic_models
 from jrdev.services.providers.open_router import fetch_open_router_models
-from jrdev.services.providers.openai import fetch_open_ai_models
 
 from typing import Any
 
@@ -9,8 +9,8 @@ class ModelFetchService:
     async def fetch_provider_models(self, provider_name: str, core_app: Any):
         if provider_name == "open_router":
             return await fetch_open_router_models()
-        elif provider_name == "openai":
-            return await fetch_open_ai_models(core_app)
         elif provider_name == "anthropic":
             return await fetch_open_anthropic_models(core_app)
-        return None
+        else:
+            # Attempt using generic open ai format to get models
+            return await fetch_openai_generic_models(core_app, provider_name)

--- a/src/jrdev/services/fetch_models_service.py
+++ b/src/jrdev/services/fetch_models_service.py
@@ -1,0 +1,7 @@
+from jrdev.services.providers.open_router import fetch_open_router_models
+
+class ModelFetchService:
+    async def fetch_provider_models(self, provider_name: str):
+        if provider_name == "open_router":
+            return await fetch_open_router_models()
+        return None

--- a/src/jrdev/services/llm_requests.py
+++ b/src/jrdev/services/llm_requests.py
@@ -56,7 +56,6 @@ async def stream_openai_format(app, model, messages, task_id=None, print_stream=
     elif model == "deepseek-r1-671b":
         kwargs["extra_body"] = {"venice_parameters": {"include_venice_system_prompt": False}}
     elif model == "deepseek-reasoner" or model == "deepseek-chat":
-        kwargs["max_tokens"] = 8000
         if model == "deepseek-chat" and json_output:
             kwargs["response_format"] = {"type": "json_object"}
     elif model_provider == "venice":
@@ -173,7 +172,7 @@ async def stream_messages_format(app, model, messages, task_id=None, print_strea
             app.logger.error(f"Error estimating input tokens for Anthropic: {e}")
 
     try:
-        kwargs = {"model": model, "messages": anthropic_messages, "max_tokens": 8192, "temperature": 0.0}
+        kwargs = {"model": model, "messages": anthropic_messages, "max_tokens": 32000, "temperature": 0.0}
         if system_message is not None:
             kwargs["system"] = system_message
         stream_manager = client.messages.stream(**kwargs)

--- a/src/jrdev/services/providers/anthropic.py
+++ b/src/jrdev/services/providers/anthropic.py
@@ -1,0 +1,50 @@
+import logging
+logger = logging.getLogger("jrdev")
+
+from datetime import timezone
+from jrdev.services.providers.models_dev import fetch_models_dot_dev
+
+async def fetch_open_anthropic_models(core_app):
+    """
+    Fetches model data from the OpenAI API and formats it into the internal model list structure.
+    """
+    client = core_app.state.clients.get_client("anthropic")
+    if not client:
+        return []
+
+    # fetch supporting details from models.dev
+    model_details = await fetch_models_dot_dev("anthropic")
+
+    try:
+        response = await client.models.list(limit=1000)
+        models = response.data
+    except Exception as e:
+        logger.error(f"Failed to fetch Anthropic models: {e}")
+        return []
+
+    logger.info(f"Fetched Anthropic models:\n{models}")
+    formatted_models = []
+    for model in models:
+        # convert time created to timestamp
+        dt = model.created_at.replace(tzinfo=timezone.utc)
+
+        formatted_model = {
+            "name": model.id,
+            "provider": "anthropic",
+            "is_think": True,
+            "input_cost": 0,
+            "output_cost": 0,
+            "context_tokens": 0,
+            "created": int(dt.timestamp()),
+        }
+
+        # add supplemental info from models.dev
+        if model.id in model_details:
+            formatted_model["input_cost"] = model_details[model.id]["input_cost"]
+            formatted_model["output_cost"] = model_details[model.id]["output_cost"]
+            formatted_model["context_tokens"] = model_details[model.id]["context_tokens"]
+
+        if formatted_model["name"]:
+            formatted_models.append(formatted_model)
+
+    return formatted_models

--- a/src/jrdev/services/providers/generic_openai.py
+++ b/src/jrdev/services/providers/generic_openai.py
@@ -1,31 +1,32 @@
 import logging
 logger = logging.getLogger("jrdev")
 
+from typing import Any
 from jrdev.services.providers.models_dev import fetch_models_dot_dev
 
-async def fetch_open_ai_models(core_app):
+async def fetch_openai_generic_models(core_app: Any, provider_name: str):
     """
     Fetches model data from the OpenAI API and formats it into the internal model list structure.
     """
-    client = core_app.state.clients.get_client("openai")
+    client = core_app.state.clients.get_client(provider_name)
     if not client:
         return []
 
     # fetch supporting details from models.dev
-    model_details = await fetch_models_dot_dev("openai")
+    model_details = await fetch_models_dot_dev(provider_name)
 
     try:
         response = await client.models.list()
         models = response.data
     except Exception as e:
-        logger.error(f"Failed to fetch OpenAI models: {e}")
+        logger.error(f"Failed to fetch {provider_name} models: {e}")
         return []
 
     formatted_models = []
     for model in models:
         formatted_model = {
             "name": model.id,
-            "provider": "openai",
+            "provider": provider_name,
             "is_think": True,
             "input_cost": 0,
             "output_cost": 0,

--- a/src/jrdev/services/providers/models_dev.py
+++ b/src/jrdev/services/providers/models_dev.py
@@ -1,0 +1,53 @@
+import httpx
+
+import logging
+logger = logging.getLogger("jrdev")
+
+async def fetch_models_dot_dev(provider_name: str):
+    """
+    Fetches model data from the OpenRouter API and formats it into the internal model list structure.
+    """
+    url = "https://models.dev/api.json"
+    formatted_models = {}
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url)
+            response.raise_for_status()  # Raise an exception for bad status codes
+            api_data = response.json()
+
+        if provider_name not in api_data or "models" not in api_data[provider_name]:
+            logger.error(f"No matches in models.dev for {provider_name}")
+            return {}
+
+        for model_name, model in api_data[provider_name]["models"].items():
+            try:
+                input_raw = float(model.get('cost', {}).get('input', '0'))
+                output_raw = float(model.get('cost', {}).get('output', '0'))
+                # models.dev gives cost per 1m tokens, JrDev stores as cost per 10m
+                input_cost = input_raw * 10
+                output_cost = output_raw * 10
+            except (ValueError, TypeError):
+                logger.info(f"Failed to parse model data price:\n {model}")
+                input_cost = 0
+                output_cost = 0
+
+            formatted_model = {
+                "name": model_name,
+                "provider": provider_name,
+                "is_think": True,  # Defaulting to True - this should be deprecated anyways
+                "input_cost": input_cost,
+                "output_cost": output_cost,
+                "context_tokens": model.get('limit', {}).get('context', 0)
+            }
+            if formatted_model["name"]:
+                formatted_models[model_name] = formatted_model
+
+    except httpx.RequestError as e:
+        logger.error(f"An error occurred while requesting {e.request.url!r}: {e}")
+        return {}
+    except Exception as e:
+        logger.error(f"An unexpected error occurred: {e}")
+        return {}
+
+    return formatted_models

--- a/src/jrdev/services/providers/open_router.py
+++ b/src/jrdev/services/providers/open_router.py
@@ -1,6 +1,4 @@
-import asyncio
 import httpx
-import json
 
 import logging
 logger = logging.getLogger("jrdev")
@@ -18,10 +16,7 @@ async def fetch_open_router_models():
             response.raise_for_status()  # Raise an exception for bad status codes
             api_data = response.json()
 
-        # The list of models is under the 'data' key
         for model in api_data.get('data', []):
-            # The pricing is given as a string per token.
-            # We convert it to an integer cost based on the internal format.
             try:
                 input_raw = float(model.get('pricing', {}).get('prompt', '0'))
                 output_raw = float(model.get('pricing', {}).get('completion', '0'))
@@ -53,15 +48,3 @@ async def fetch_open_router_models():
         return []
 
     return formatted_models
-
-async def main():
-    """
-    Main function to fetch and print the formatted model list.
-    """
-    models = await fetch_open_router_models()
-    if models:
-        # Pretty print the JSON output, matching the structure of model_list.json
-        print(json.dumps({"models": models}, indent=4))
-
-if __name__ == "__main__":
-    asyncio.run(main())

--- a/src/jrdev/services/providers/open_router.py
+++ b/src/jrdev/services/providers/open_router.py
@@ -1,0 +1,67 @@
+import asyncio
+import httpx
+import json
+
+import logging
+logger = logging.getLogger("jrdev")
+
+async def fetch_open_router_models():
+    """
+    Fetches model data from the OpenRouter API and formats it into the internal model list structure.
+    """
+    url = "https://openrouter.ai/api/v1/models"
+    formatted_models = []
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url)
+            response.raise_for_status()  # Raise an exception for bad status codes
+            api_data = response.json()
+
+        # The list of models is under the 'data' key
+        for model in api_data.get('data', []):
+            # The pricing is given as a string per token.
+            # We convert it to an integer cost based on the internal format.
+            try:
+                input_raw = float(model.get('pricing', {}).get('prompt', '0'))
+                output_raw = float(model.get('pricing', {}).get('completion', '0'))
+                # open router gives pricing per token, we store pricing per 10,000,000 tokens
+                input_cost = input_raw * float(10_000_000)
+                output_cost = output_raw * float(10_000_000)
+            except (ValueError, TypeError):
+                logger.info(f"Failed to parse model data price:\n {model}")
+                input_cost = 0
+                output_cost = 0
+
+            formatted_model = {
+                "name": model.get('id'),
+                "provider": "open_router",
+                "is_think": True,  # Defaulting to True - this should be deprecated anyways
+                "input_cost": input_cost,
+                "output_cost": output_cost,
+                "context_tokens": model.get('context_length', 0),
+                "created": model.get('created', 0)
+            }
+            if formatted_model["name"]:
+                formatted_models.append(formatted_model)
+
+    except httpx.RequestError as e:
+        logger.error(f"An error occurred while requesting {e.request.url!r}: {e}")
+        return []
+    except Exception as e:
+        logger.error(f"An unexpected error occurred: {e}")
+        return []
+
+    return formatted_models
+
+async def main():
+    """
+    Main function to fetch and print the formatted model list.
+    """
+    models = await fetch_open_router_models()
+    if models:
+        # Pretty print the JSON output, matching the structure of model_list.json
+        print(json.dumps({"models": models}, indent=4))
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/jrdev/services/providers/openai.py
+++ b/src/jrdev/services/providers/openai.py
@@ -1,0 +1,45 @@
+import logging
+logger = logging.getLogger("jrdev")
+
+from jrdev.services.providers.models_dev import fetch_models_dot_dev
+
+async def fetch_open_ai_models(core_app):
+    """
+    Fetches model data from the OpenAI API and formats it into the internal model list structure.
+    """
+    client = core_app.state.clients.get_client("openai")
+    if not client:
+        return []
+
+    # fetch supporting details from models.dev
+    model_details = await fetch_models_dot_dev("openai")
+
+    try:
+        response = await client.models.list()
+        models = response.data
+    except Exception as e:
+        logger.error(f"Failed to fetch OpenAI models: {e}")
+        return []
+
+    formatted_models = []
+    for model in models:
+        formatted_model = {
+            "name": model.id,
+            "provider": "openai",
+            "is_think": True,
+            "input_cost": 0,
+            "output_cost": 0,
+            "context_tokens": 0,
+            "created": model.created
+        }
+
+        # add supplemental info from models.dev
+        if model.id in model_details:
+            formatted_model["input_cost"] = model_details[model.id]["input_cost"]
+            formatted_model["output_cost"] = model_details[model.id]["output_cost"]
+            formatted_model["context_tokens"] = model_details[model.id]["context_tokens"]
+
+        if formatted_model["name"]:
+            formatted_models.append(formatted_model)
+
+    return formatted_models

--- a/src/jrdev/ui/textual_ui.py
+++ b/src/jrdev/ui/textual_ui.py
@@ -359,7 +359,7 @@ class JrDevUI(App[None]):
         """Open the SettingsScreen with Management view active by default."""
         if not self.settings_screen:
             self.settings_screen = SettingsScreen(core_app=self.jrdev)
-            self.settings_screen.active_view = "management"
+            self.settings_screen.active_view = "model_management"
             self.app.push_screen(screen=self.settings_screen, callback=self.handle_settings_screen_closed)
 
     def handle_settings_screen_closed(self, success: bool) -> None:
@@ -423,7 +423,7 @@ class JrDevUI(App[None]):
     @on(events.DescendantBlur, "#model-search-input")
     def handle_modellistview_blur(self, event: events.DescendantBlur):
         # Only close if focus is truly leaving the entire model list view
-        model_listview: ModelListView = event.widget.parent
+        model_listview: ModelListView = event.widget.parent.parent
         if not model_listview.has_focus:
             model_listview.set_visible(False)
 

--- a/src/jrdev/ui/tui/base_model_modal.py
+++ b/src/jrdev/ui/tui/base_model_modal.py
@@ -145,10 +145,12 @@ class BaseModelModal(ModalScreen):
         )
 
     def actions_row(self) -> Horizontal:
-        """Return a row with Save and Cancel buttons."""
+        """Return a row with Save and Cancel buttons, ensuring standard IDs."""
+        save_button = Button("Save", id="save")
+        cancel_button = Button("Cancel", id="cancel")
         return Horizontal(
-            Button("Save", id="save"),
-            Button("Cancel", id="cancel"),
+            save_button,
+            cancel_button,
             classes="form-actions"
         )
 

--- a/src/jrdev/ui/tui/import_models_modal.py
+++ b/src/jrdev/ui/tui/import_models_modal.py
@@ -69,6 +69,7 @@ class ImportModelsModal(BaseModelModal):
     def on_mount(self):
         table = self.query_one(DataTable)
         table.cursor_type = "row"
+        table.zebra_stripes = True
         # Add columns with keys to support sorting and header label updates
         table.add_column("[yellow]-[/]", key="select")
         table.add_column("Name [yellow]-[/]", key="name")

--- a/src/jrdev/ui/tui/import_models_modal.py
+++ b/src/jrdev/ui/tui/import_models_modal.py
@@ -1,0 +1,149 @@
+from typing import List, Dict, Any, Set
+from textual.widgets import Button, DataTable
+from textual.binding import Binding
+from textual.widgets.data_table import RowKey
+from textual import on
+from datetime import datetime
+
+from jrdev.ui.tui.base_model_modal import BaseModelModal
+from jrdev.ui.tui.command_request import CommandRequest
+
+class ImportModelsModal(BaseModelModal):
+    """A modal to import models from a provider."""
+
+    DEFAULT_CSS = BaseModelModal.DEFAULT_CSS + """
+    ImportModelsModal > .model-modal-container {
+        border: round $accent;
+        width: 80%;
+        height: 80%;
+    }
+    #import-models-table {
+        height: 1fr;
+        border: round $accent;
+        margin-top: 1;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "app.pop_screen", "Close", show=False),
+    ]
+
+    def __init__(self, models: List[Dict[str, Any]], provider_name: str, **kwargs):
+        super().__init__(**kwargs)
+        self.models_to_import = models
+        self.provider_name = provider_name
+        self.selected_rows: Set[RowKey] = set()
+        self._row_key_to_model: Dict[RowKey, Dict[str, Any]] = {}
+
+    def compose(self):
+        container, header = self.build_container("import-models-container", f"Import Models from {self.provider_name}")
+        with container:
+            yield header
+            yield DataTable(id="import-models-table")
+
+            # Build actions row using the base class helper to ensure consistent IDs
+            actions = self.actions_row()
+            # Access the known save button (id="save") and adjust its label
+            for child in actions.children:
+                if isinstance(child, Button) and child.id == "save":
+                    child.label = "Import"
+                    break
+            yield actions
+
+    def on_mount(self):
+        table = self.query_one(DataTable)
+        table.cursor_type = "row"
+        table.add_columns("✓", "Name", "Date Added", "Context", "Input Cost/1M", "Output Cost/1M")
+        
+        # Build a set of existing local model names (as stored in jrdev)
+        existing_model_names = {str(model.get('name', '')).strip() for model in self.app.jrdev.get_models() if model.get('name')}
+
+        for model in self.models_to_import:
+            # Prefer a 'name' field if present; otherwise fall back to 'id'
+            raw_name = model.get('name') or model.get('id')
+            candidate_name = str(raw_name).strip() if raw_name else ""
+            if not candidate_name:
+                # If we cannot determine a comparable name, skip this entry
+                continue
+            # Only skip when the candidate name exactly matches an existing local model name
+            if candidate_name in existing_model_names:
+                continue
+
+            # stored locally as cost per 10m tokens
+            input_cost_per_1M = model.get("input_cost", 0) / 10
+            output_cost_per_1M = model.get("output_cost", 0) / 10
+
+            context_length = model.get('context_tokens', 0)
+
+            # unix time that model was created
+            created_time = model.get('created', 0)
+            created_time_str = datetime.fromtimestamp(created_time).strftime('%Y-%m-%d')
+            
+            input_cost_str = f"${input_cost_per_1M:.2f}"
+            output_cost_str = f"${output_cost_per_1M:.2f}"
+
+            row_key = table.add_row(
+                "☐",
+                candidate_name,
+                created_time_str,
+                str(context_length),
+                input_cost_str,
+                output_cost_str,
+                key=candidate_name
+            )
+            self._row_key_to_model[row_key] = model
+
+    @on(DataTable.RowSelected, "#import-models-table")
+    def toggle_row_selection(self, event: DataTable.RowSelected):
+        table = self.query_one(DataTable)
+        row_key = event.row_key
+        if not row_key:
+            return
+        check_col_key = table.ordered_columns[0].key
+        if check_col_key is None:
+            return
+        if row_key in self.selected_rows:
+            self.selected_rows.remove(row_key)
+            table.update_cell(row_key, column_key=check_col_key, value="☐")
+        else:
+            self.selected_rows.add(row_key)
+            table.update_cell(row_key, column_key=check_col_key, value="☑")
+        
+        table.move_cursor(row=-1)
+
+    @on(Button.Pressed)
+    def handle_button_press(self, event: Button.Pressed):
+        if event.button.id == "save":
+            if not self.selected_rows:
+                self.app.notify("No models selected for import.", severity="warning")
+                return
+
+            for row_key in self.selected_rows:
+                model_data = self._row_key_to_model.get(row_key)
+                if not model_data:
+                    continue
+
+                # Use the same candidate name logic for consistency when issuing the add command
+                name = (model_data.get('name') or model_data.get('id'))
+                if not name:
+                    continue
+                name = str(name).strip()
+
+                provider = self.provider_name
+                is_think = "true"
+                
+                input_cost_per_token = float(model_data.get('pricing', {}).get('input', '0'))
+                output_cost_per_token = float(model_data.get('pricing', {}).get('output', '0'))
+            
+                input_cost_per_1M = input_cost_per_token * 1_000_000
+                output_cost_per_1M = output_cost_per_token * 1_000_000
+
+                context_window = model_data.get('context_length', 0)
+
+                command = f"/model add {name} {provider} {is_think} {input_cost_per_1M:.6f} {output_cost_per_1M:.6f} {context_window}"
+                self.post_message(CommandRequest(command))
+            
+            self.app.pop_screen()
+            self.app.notify(f"Importing {len(self.selected_rows)} models...")
+        elif event.button.id == "cancel":
+            self.app.pop_screen()

--- a/src/jrdev/ui/tui/model_listview.py
+++ b/src/jrdev/ui/tui/model_listview.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from textual import on, events
 from textual.color import Color
+from textual.containers import Horizontal
 from textual.geometry import Offset
 from textual.message import Message
 from textual.widget import Widget
@@ -24,10 +25,24 @@ class ModelListView(Widget):
     DEFAULT_CSS = """
     #model-search-input {
         border: none;
+        height: 1;
+        padding: 0;
+        margin: 0;
+        width: 1fr;
+    }
+    #layout-top {
+        border: none;
         height: 2;
         border-bottom: solid;
         padding: 0;
         margin: 0;
+    }
+    #btn-settings {
+        height: 1;
+        width: 3;
+        max-width: 3;
+        margin: 0;
+        padding: 0;
     }
     """
 
@@ -54,11 +69,14 @@ class ModelListView(Widget):
         self.height = 10
         self.models = []
         self.search_input = SearchInput(placeholder="Search models...", id="model-search-input")
+        self.btn_settings = Button("⚙️", id="btn-settings", tooltip="Model & Provider Settings")
         self.list_view = ListView(id="_listview")
         self.input_query = None
 
     def compose(self):
-        yield self.search_input
+        with Horizontal(id="layout-top"):
+            yield self.search_input
+            yield self.btn_settings
         yield self.list_view
 
     def update_models(self, query_filter: str = "") -> None:
@@ -184,3 +202,7 @@ class ModelListView(Widget):
     def selection_updated(self, selected: ListView.Selected) -> None:
         if not selected.item.disabled:
             self.post_message(self.ModelSelected(self, selected.item.name))
+
+    @on(Button.Pressed, "#btn-settings")
+    def handle_settings_pressed(self):
+        self.app.handle_settings_pressed()

--- a/src/jrdev/ui/tui/model_management_widget.py
+++ b/src/jrdev/ui/tui/model_management_widget.py
@@ -326,7 +326,7 @@ class ModelManagementWidget(Widget):
         try:
             fetch_button.disabled = True
             self.app.notify(f"Fetching models for {provider_name}...")
-            models = await self.core_app.model_fetch_service.fetch_provider_models(provider_name)
+            models = await self.core_app.model_fetch_service.fetch_provider_models(provider_name, self.app.jrdev)
 
             if models:
                 await self.app.push_screen(ImportModelsModal(models=models, provider_name=provider_name))

--- a/src/jrdev/ui/tui/model_management_widget.py
+++ b/src/jrdev/ui/tui/model_management_widget.py
@@ -56,6 +56,12 @@ class ModelManagementWidget(Widget):
         height: auto;
     }
     
+    #provider-buttons-layout {
+        height: 1;
+        margin: 0;
+        padding: 0;
+    }
+    
     .provider-button {
         margin-left: 1;
         width: 6;
@@ -65,6 +71,9 @@ class ModelManagementWidget(Widget):
         margin-left: 1;
         width: 2;
         max-width: 3;
+    }
+    #provider-fetch {
+        margin-top: 1;
     }
     .model-button {
         margin-left: 1;
@@ -142,7 +151,7 @@ class ModelManagementWidget(Widget):
                     yield Button("+", id="add-provider", classes="provider-button-add-remove", tooltip="Add new provider")
                     yield Button("-", id="remove-provider", classes="provider-button-add-remove", tooltip="Remove selected provider")
                     yield Button("Edit", id="edit-provider", classes="provider-button", tooltip="Edit selected provider")
-                yield Button("Fetch Provider Models", id="provider-fetch")
+                yield Button("Fetch Models", id="provider-fetch", tooltip="Fetch the updated list of models for the selected provider")
             with Container(id="right-pane"):
                 yield Label("Models")
                 with ScrollableContainer(id="models-scroll"):
@@ -158,6 +167,9 @@ class ModelManagementWidget(Widget):
         self.populate_models()
         # initialize CRUD buttons state
         self._update_model_crud_buttons_state(False)
+        # Disable Fetch Models button until a provider is selected
+        fetch_button = self.query_one("#provider-fetch", Button)
+        fetch_button.disabled = True
 
     def populate_providers(self):
         """Populates the provider select widget."""
@@ -248,6 +260,10 @@ class ModelManagementWidget(Widget):
     @on(Select.Changed, "#provider-select")
     def handle_provider_change(self, event: Select.Changed):
         """Handle provider selection changes."""
+        provider_select = self.query_one("#provider-select", Select)
+        fetch_button = self.query_one("#provider-fetch", Button)
+        selected = provider_select.value
+        fetch_button.disabled = (not selected or selected == "all" or selected == Select.BLANK)
         self.populate_models(event.value)
 
     @on(DataTable.RowHighlighted, "#models-table")


### PR DESCRIPTION
## Add provider model discovery and import workflow

This pull request introduces a complete end-to-end workflow for discovering and importing models directly from supported providers. Users can now refresh the list of available models for any configured provider and selectively import new ones without leaving the application.

<img width="1199" height="660" alt="Screenshot from 2025-08-04 15-39-30" src="https://github.com/user-attachments/assets/a158593f-39bc-4905-9859-897a0c089c16" />

### What This Means for Users

- **One-click model discovery**: A new **"Fetch Models"** button in the Model Management view queries the selected provider for its current catalog.
- **Selective import**: After fetching, a searchable table displays only the models that are not yet present locally. Users can check the ones they want and import them in bulk.
- **Up-to-date pricing and context limits**: Model metadata—including cost per token and context window size—is pulled from both the provider’s API and the public [models.dev](https://models.dev) registry, ensuring accurate estimates before use.
- **Improved navigation**: A settings (⚙️) icon has been added to the model-selection dropdown for quicker access to provider and model management.

### A Closer Look at the Changes

#### Provider-specific fetchers
- **`services/providers/open_router.py`**, **`anthropic.py`**, and **`generic_openai.py`**  
  Lightweight, provider-aware clients that retrieve model lists via REST or the native SDK and normalize the data into the internal schema.

- **`services/providers/models_dev.py`**  
  Augments provider responses with pricing and context-window data from the open [models.dev](https://models.dev) API, reducing the need for manual entry.

- **`services/fetch_models_service.py`**  
  Acts as a dispatcher: given a provider name, it delegates to the correct fetcher and returns a uniform list of model dictionaries.

#### Import UI
- **`ui/tui/import_models_modal.py`**  
  A new modal that presents the fetched models in a sortable table. Users can select individual rows or rely on the default “newest first” ordering. Duplicate detection prevents clutter by hiding models that already exist locally.

- **`ui/tui/model_management_widget.py`**  
  - Added **"Fetch Models"** button (disabled until a single provider is selected).  
  - Integrated column sorting for the models table.  
  - Refreshes the view after import so new models appear immediately.

#### Supporting tweaks
- **`requirements.txt`**  
  Added `httpx` for async HTTP requests used by the fetchers.

- **`core/application.py`**  
  Registered `ModelFetchService` as a lightweight service accessible throughout the UI.

- **`agents/router_agent.py`**  
  Added a guard clause to prevent crashes when the router returns `"execute_action"` without an accompanying action payload.

- **`ui/tui/model_listview.py`**  
  Added a settings button to the search bar for parity with the management view.

- **`ui/tui/base_model_modal.py`**  
  Ensured consistent button IDs (`#save`, `#cancel`) across all modals for reliable event handling.

- **`services/llm_requests.py`**  
  Removed the hard-coded 8 k token cap for DeepSeek models, allowing the full 32 k context to be used when needed.
`Generated by JrDev AI using moonshotai/kimi-k2-instruct`