### PR TITLE
feat: Add unit tests for file_utils.py

### DIFF
--- a/src/jrdev/file_operations/file_utils.py
+++ b/src/jrdev/file_operations/file_utils.py
@@ -269,13 +269,15 @@ def add_to_gitignore(gitignore_path: str, ignore_str: str, create_if_dne: bool =
             if ignore_pattern in lines:
                 return True
 
-            # Add a newline at the end if needed
-            needs_newline = lines and lines[-1] != ""
+            # Read the entire file content to check for a trailing newline
+            with open(gitignore_path, 'r') as f:
+                content = f.read()
 
             # Append the pattern to the file
             with open(gitignore_path, 'a') as f:
-                if needs_newline:
-                    f.write("\n")
+                # Add a newline only if the file is not empty and doesn't already end with a newline
+                if content and not content.endswith('\n'):
+                    f.write('\n')
                 f.write(f"{ignore_pattern}\n")
 
             logger.info(f"Added '{ignore_pattern}' to {gitignore_path}")

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,0 +1,70 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch, mock_open
+
+from jrdev.file_operations.file_utils import (
+    add_to_gitignore,
+    cutoff_string,
+    pair_header_source_files,
+)
+
+
+class TestFileUtils(unittest.TestCase):
+    def test_cutoff_string(self):
+        self.assertEqual(
+            cutoff_string("<a><b></c>", "<a>", "</c>"),
+            "<b>"
+        )
+        self.assertEqual(
+            cutoff_string("<a><b><c>", "<d>", "<c>"),
+            "<a><b>"
+        )
+        self.assertEqual(
+            cutoff_string("<a><b><c>", "<a>", "<d>"),
+            "<b><c>"
+        )
+        self.assertEqual(
+            cutoff_string("<a><b><c>", "<d>", "</d>"),
+            "<a><b><c>"
+        )
+        self.assertEqual(
+            cutoff_string("", "<a>", "<b>"),
+            ""
+        )
+        self.assertEqual(
+            cutoff_string("<a><b>", "<a>", "<b>"),
+            ""
+        )
+
+    def test_pair_header_source_files(self):
+        file_list = [
+            "src/main.cpp",
+            "src/main.h",
+            "src/utils.cpp",
+            "src/utils.h",
+            "src/other.txt",
+        ]
+        paired_list = pair_header_source_files(file_list)
+        self.assertIn(["src/main.cpp", "src/main.h"], paired_list)
+        self.assertIn(["src/utils.cpp", "src/utils.h"], paired_list)
+        self.assertIn(["src/other.txt"], paired_list)
+
+    def test_add_to_gitignore(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            gitignore_path = os.path.join(tmpdir, ".gitignore")
+
+            # Test creating a new file
+            self.assertTrue(add_to_gitignore(gitignore_path, "*.log", create_if_dne=True))
+            with open(gitignore_path, "r") as f:
+                self.assertEqual(f.read(), "*.log\n")
+
+            # Test adding a new pattern to an existing file
+            self.assertTrue(add_to_gitignore(gitignore_path, "*.tmp"))
+            with open(gitignore_path, "r") as f:
+                self.assertEqual(f.read(), "*.log\n*.tmp\n")
+
+            # Test adding a pattern that already exists
+            self.assertTrue(add_to_gitignore(gitignore_path, "*.log"))
+            with open(gitignore_path, "r") as f:
+                self.assertEqual(f.read(), "*.log\n*.tmp\n")


### PR DESCRIPTION
This commit introduces unit tests for several functions in the `file_utils.py` module, increasing the overall test coverage of the project.

The new tests cover the following functions:
- `cutoff_string`: Verifies that the string cutting functionality works as expected.
- `pair_header_source_files`: Ensures that C++ header and source files are correctly paired.
- `add_to_gitignore`: Tests the functionality of adding patterns to a `.gitignore` file.

A bug was discovered in the `add_to_gitignore` function where an extra newline was being added incorrectly. This bug has been fixed as part of this commit. Additionally, some assertions in the `cutoff_string` tests were corrected to ensure their accuracy.