### PR TITLE
test: Add unit test for model config validation + remove venice from provider default

### DIFF
--- a/src/jrdev/config/api_providers.json
+++ b/src/jrdev/config/api_providers.json
@@ -1,24 +1,6 @@
 {
   "providers": [
     {
-      "name": "venice",
-      "env_key": "VENICE_API_KEY",
-      "base_url": "https://api.venice.ai/api/v1",
-      "required": false,
-      "default_profiles": {
-        "profiles": {
-          "advanced_reasoning": "deepseek-r1-671b",
-          "advanced_coding": "qwen3-235b",
-          "intermediate_reasoning": "qwen3-235b",
-          "intermediate_coding": "qwen3-235b",
-          "quick_reasoning": "llama-3.3-70b",
-          "intent_router": "llama-3.3-70b",
-          "low_cost_search": "llama-3.3-70b"
-        },
-        "default_profile": "advanced_coding"
-      }
-    },
-    {
       "name": "openai",
       "env_key": "OPENAI_API_KEY",
       "base_url": null,

--- a/src/jrdev/config/model_list.json
+++ b/src/jrdev/config/model_list.json
@@ -183,6 +183,14 @@
             "input_cost": 20,
             "output_cost": 80,
             "context_tokens": 1047576
+        },
+        {
+            "name": "gemma3:4b",
+            "provider": "ollama",
+            "is_think": false,
+            "input_cost": 0,
+            "output_cost": 0,
+            "context_tokens": 8192
         }
     ]
 }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,39 @@
+import json
+import os
+
+def test_model_profiles_are_valid():
+    """
+    Tests that all models in the default profiles of api_providers.json are valid models
+    in model_list.json.
+    """
+    # Construct absolute paths to the JSON files
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    api_providers_path = os.path.join(current_dir, '..', 'src', 'jrdev', 'config', 'api_providers.json')
+    model_list_path = os.path.join(current_dir, '..', 'src', 'jrdev', 'config', 'model_list.json')
+
+    # Load the JSON files
+    with open(api_providers_path, 'r') as f:
+        api_providers = json.load(f)
+    with open(model_list_path, 'r') as f:
+        model_list = json.load(f)
+
+    # Extract all model names from api_providers.json
+    provider_models = []
+    for provider in api_providers['providers']:
+        if 'default_profiles' in provider and 'profiles' in provider['default_profiles']:
+            provider_models.extend(provider['default_profiles']['profiles'].values())
+
+    # Extract all valid model ids from model_list.json
+    # The model list can have 'id' or 'name' for the model identifier. Let's check for both.
+    valid_model_ids = set()
+    if 'models' in model_list:
+        for model in model_list['models']:
+            if 'id' in model:
+                valid_model_ids.add(model['id'])
+            if 'name' in model:
+                valid_model_ids.add(model['name'])
+
+
+    # Check that each provider model is in the valid model list
+    for model_name in provider_models:
+        assert model_name in valid_model_ids, f"Model '{model_name}' not found in model_list.json"


### PR DESCRIPTION
Adds a new unit test to validate that all models specified in the `api_providers.json` configuration file are present in the `model_list.json` file.

This test uncovered some inconsistencies in the configuration data, which have been fixed in this commit:
- Added the missing 'gemma3:4b' model for the 'ollama' provider to `model_list.json`.

refactor: Remove venice provider

Removes the 'venice' provider from the `api_providers.json`.