### PR TITLE
feat: add groq provider and moonshotai/kimi-k2-instruct model

### DIFF
--- a/src/jrdev/config/api_providers.json
+++ b/src/jrdev/config/api_providers.json
@@ -107,6 +107,24 @@
         },
         "default_profile": "advanced_coding"
       }
+    },
+    {
+      "name": "groq",
+      "env_key": "GROQ_API_KEY",
+      "base_url": "https://api.groq.com/openai/v1",
+      "required": false,
+      "default_profiles": {
+          "profiles": {
+          "advanced_reasoning": "moonshotai/kimi-k2-instruct",
+          "advanced_coding": "moonshotai/kimi-k2-instruct",
+          "intermediate_reasoning": "moonshotai/kimi-k2-instruct",
+          "intermediate_coding": "moonshotai/kimi-k2-instruct",
+          "quick_reasoning": "moonshotai/kimi-k2-instruct",
+          "intent_router": "moonshotai/kimi-k2-instruct",
+          "low_cost_search": "moonshotai/kimi-k2-instruct"
+        },
+        "default_profile": "advanced_coding"
+      }
     }
   ]
 }

--- a/src/jrdev/config/model_list.json
+++ b/src/jrdev/config/model_list.json
@@ -207,6 +207,14 @@
             "input_cost": 3,
             "output_cost": 25,
             "context_tokens": 1000000
+        },
+        {
+            "name": "moonshotai/kimi-k2-instruct",
+            "provider": "groq",
+            "is_think": false,
+            "input_cost": 10,
+            "output_cost": 30,
+            "context_tokens": 131072
         }
     ]
 }


### PR DESCRIPTION
Adds support for the Groq API provider and registers the Moonshot AI Kimi-K2 model for use across all default profiles.