### PR TITLE
Add OpenRouter quantization support and propagate model names through assistant messages

### DIFF
--- a/src/jrdev/agents/pipeline/fetch_context_phase.py
+++ b/src/jrdev/agents/pipeline/fetch_context_phase.py
@@ -142,8 +142,8 @@ class FetchContextPhase(Stage):
             self.app.ui.update_task_info(sub_task_str, update={"sub_task_finished": True})
 
         json_content = cutoff_string(response, "```json", "```")
-        tool_calls = json.loads(json_content)
         try:
+            tool_calls = json.loads(json_content)
             if tool_calls:
                 tool = tool_calls.get("tool")
                 if tool and tool == "read":
@@ -154,7 +154,7 @@ class FetchContextPhase(Stage):
                             if file not in files:
                                 files.append(file)
                                 self.app.logger.info(f"Adding file {file}")
-        except AttributeError as e:
+        except (json.JSONDecodeError, TypeError, AttributeError) as e:
             self.app.logger.error("ask_files_sufficient: malformed additional files response %s", str(e))
             self.app.ui.print_text("ask_files_sufficient response malformed", PrintType.ERROR)
         return files

--- a/src/jrdev/agents/research_agent.py
+++ b/src/jrdev/agents/research_agent.py
@@ -94,9 +94,7 @@ class ResearchAgent:
                         summary_parts.append("No research actions were taken.")
 
                     summary = "\n".join(summary_parts)
-                    self.thread.messages.append(
-                        {"role": "assistant", "content": summary}
-                    )
+                    self.thread.add_response(summary, model=research_model)
                     return {"type": "summary", "data": summary}
 
         if response_json is None:
@@ -111,9 +109,7 @@ class ResearchAgent:
             return None
 
         # Add the structured assistant response to history *after* successful parsing.
-        self.thread.messages.append(
-            {"role": "assistant", "content": json.dumps(response_json, indent=2)}
-        )
+        self.thread.add_response(json.dumps(response_json, indent=2), model=research_model)
 
         decision = response_json.get("decision")
 
@@ -147,7 +143,7 @@ class ResearchAgent:
         if decision == "summary":
             summary = response_json.get("response", "")
             # Add summary to thread as final assistant message
-            self.thread.messages.append({"role": "assistant", "content": summary})
+            self.thread.add_response(summary, model=research_model)
             return {"type": "summary", "data": summary}
 
         self.logger.error(f"Research agent returned an unknown decision: {decision}. Aborting.")

--- a/src/jrdev/agents/router_agent.py
+++ b/src/jrdev/agents/router_agent.py
@@ -67,6 +67,7 @@ class CommandInterpretationAgent:
 
         # Use a specific, fast model for this routing task
         router_model = self.app.profile_manager().get_model("intent_router")
+        response_model = router_model
         response_text = await generate_llm_response(self.app, router_model, messages, task_id=worker_id)
 
         # The user's input is part of the request, so add it to history.
@@ -97,6 +98,7 @@ class CommandInterpretationAgent:
             salvage_builder.add_user_message(response_text)
 
             salvage_model = self.app.profile_manager().get_model("quick_reasoning")
+            response_model = salvage_model
             response_text = await generate_llm_response(self.app, salvage_model, salvage_builder.build(), task_id=worker_id)
 
             try:
@@ -105,15 +107,13 @@ class CommandInterpretationAgent:
             except (json.JSONDecodeError, KeyError) as e2:
                 self.logger.error(f"Failed to parse router JSON response{e2}\nResponse:\n {response_text}\n")
                 msg = "Sorry, I had issues parsing my response. Do you want to try again?"
-                self.thread.messages.append({"role": "assistant", "content": msg})
+                self.thread.add_response(msg, model=response_model)
                 self.app.ui.print_text(msg, print_type=PrintType.ERROR)
                 return None
 
         # Add the structured assistant response to history *after* successful parsing.
         # The content is the JSON string of the decision.
-        self.thread.messages.append(
-            {"role": "assistant", "content": json.dumps(response_json, indent=2)}
-        )
+        self.thread.add_response(json.dumps(response_json, indent=2), model=response_model)
 
         decision = response_json.get("decision")
 

--- a/src/jrdev/commands/compact.py
+++ b/src/jrdev/commands/compact.py
@@ -127,7 +127,7 @@ async def handle_compact(app: Any, args: List[str], worker_id: str) -> None:
                 # Create new messages in the required format
                 new_messages = [
                     {"role": "user", "content": compact_data["user"]},
-                    {"role": "assistant", "content": compact_data["assistant"]},
+                    {"role": "assistant", "content": compact_data["assistant"], "model": model},
                 ]
 
                 # Replace the thread's messages with just these two

--- a/src/jrdev/commands/help.py
+++ b/src/jrdev/commands/help.py
@@ -82,7 +82,7 @@ async def handle_help(app: Any, args: List[str], _worker_id: str):
     app.ui.print_text(
         f"  {cmd_format}{format_command_with_args('/model', '<list|set|remove|add|edit> [args]')}{reset} "
         "- Manage and add models (/model add|edit <name> <provider> <is_think> <input_cost> <output_cost> "
-        "<context_window>)",
+        "<context_window>; /model <name> quantizations [int4, int8] for OpenRouter)",
         print_type=None,
     )
     app.ui.print_text(f"  {cmd_format}/models{reset} - List all available models", print_type=None)
@@ -215,7 +215,7 @@ async def handle_help_plain(app: Any, _args: List[str]):
 
     app.ui.print_text(
         "  /model <list|set|remove|add|edit> [args] - Manage and add models (/model add|edit <name> <provider> "
-        "<is_think> <input_cost> <output_cost> <context_window>)",
+        "<is_think> <input_cost> <output_cost> <context_window>; /model <name> quantizations [int4, int8] for OpenRouter)",
         print_type=None,
     )
     app.ui.print_text("  /models - List all available models", print_type=None)

--- a/src/jrdev/commands/model.py
+++ b/src/jrdev/commands/model.py
@@ -4,6 +4,8 @@
 Model command implementation for the JrDev terminal.
 Manages the user's list of available models and the active chat model.
 """
+from __future__ import annotations
+
 from typing import Any, List, Union
 
 from jrdev.ui.ui import PrintType

--- a/src/jrdev/commands/model.py
+++ b/src/jrdev/commands/model.py
@@ -9,6 +9,8 @@ from typing import Any, List, Union
 from jrdev.ui.ui import PrintType
 from jrdev.utils.string_utils import is_valid_context_window, is_valid_cost, is_valid_name
 
+OPENROUTER_PROVIDER = "open_router"
+
 
 def _parse_bool(val: str) -> bool:
     """Parse a string to boolean, accepting common true/false values."""
@@ -19,6 +21,31 @@ def _parse_bool(val: str) -> bool:
     if val.lower() in false_vals:
         return False
     raise ValueError(f"Invalid boolean value: {val}")
+
+
+def _parse_quantizations(args: List[str]) -> List[str] | None:
+    """Parse a quantization list from CLI args such as [int4, int8]."""
+    raw = " ".join(args).strip()
+    if raw.startswith("[") and raw.endswith("]"):
+        raw = raw[1:-1].strip()
+
+    if not raw:
+        return None
+
+    if "," in raw:
+        quantizations = [item.strip() for item in raw.split(",")]
+    else:
+        quantizations = raw.split()
+
+    quantizations = [item for item in quantizations if item]
+    if not quantizations:
+        return None
+
+    for quantization in quantizations:
+        if not is_valid_name(quantization, max_len=32):
+            return None
+
+    return quantizations
 
 
 # pylint: disable=too-many-return-statements
@@ -101,6 +128,8 @@ async def handle_model(app, args: List[str], _worker_id: str):
       list                          - Shows all models available in your configuration.
       set <model_name>              - Sets the active model for the chat.
       remove <model_name>           - Removes a model from your configuration.
+      <model_name> quantizations [values]
+                                    - Sets OpenRouter provider quantization filters.
       add <name> <provider> <is_think> <input> <output> <context>
                                     - Adds a new model to your configuration.
       edit <name> <provider> <is_think> <input> <output> <context>
@@ -125,6 +154,8 @@ async def handle_model(app, args: List[str], _worker_id: str):
         "  /model list                       - Shows all models available in your user_models.json.\n"
         "  /model set <model_name>           - Sets the active model for the chat.\n"
         "  /model remove <model_name>        - Removes a model from your user_models.json.\n"
+        "  /model <model_name> quantizations [int4, int8]\n"
+        "      - Set OpenRouter provider quantization filters for a model.\n"
         "  /model add <name> <provider> <is_think> <input_cost> <output_cost> <context_window>\n"
         "      - Add a new model to your user_models.json.\n"
         "        <input_cost> and <output_cost> are the cost per 1,000,000 tokens (as a float, in dollars).\n"
@@ -145,6 +176,10 @@ async def handle_model(app, args: List[str], _worker_id: str):
         return
 
     subcommand = args[1].lower()
+    if len(args) >= 3 and args[2].lower() == "quantizations":
+        _handle_quantizations(app, args, available_model_names)
+        return
+
     _handle_subcommand(app, subcommand, args, available_model_names)
 
     if subcommand not in ["list", "set", "remove", "add", "edit"]:
@@ -172,6 +207,48 @@ def _handle_subcommand(app: Any, subcommand: str, args: List[str], available_mod
 
     if subcommand == "edit":
         _handle_edit(app, args, available_model_names)
+
+
+def _handle_quantizations(app: Any, args: List[str], available_model_names: List[str]) -> None:
+    if len(args) < 4:
+        app.ui.print_text("Usage: /model <model_name> quantizations [int4, int8]", PrintType.ERROR)
+        return
+
+    model_name = args[1]
+    if model_name not in available_model_names:
+        app.ui.print_text(f"Error: Model '{model_name}' not found in your configuration.", PrintType.ERROR)
+        return
+
+    model_info = next((model for model in app.get_models() if model["name"] == model_name), None)
+    if not model_info:
+        app.ui.print_text(f"Error: Model '{model_name}' not found in your configuration.", PrintType.ERROR)
+        return
+
+    provider = model_info.get("provider")
+    if provider != OPENROUTER_PROVIDER:
+        app.ui.print_text(
+            f"Error: Quantizations can only be set for OpenRouter models. '{model_name}' uses provider '{provider}'.",
+            PrintType.ERROR,
+        )
+        return
+
+    quantizations = _parse_quantizations(args[3:])
+    if quantizations is None:
+        app.ui.print_text(
+            "Invalid quantizations. Usage: /model <model_name> quantizations [int4, int8]", PrintType.ERROR
+        )
+        return
+
+    if not app.set_model_quantizations(model_name, quantizations):
+        app.logger.info(f"Failed to set quantizations for model {model_name}")
+        app.ui.print_text(f"Failed to set quantizations for model '{model_name}'", PrintType.ERROR)
+        return
+
+    app.logger.info(f"Set quantizations for model {model_name}: {quantizations}")
+    app.ui.print_text(
+        f"Set quantizations for model '{model_name}' to: {', '.join(quantizations)}",
+        PrintType.SUCCESS,
+    )
 
 
 def _handle_set(app: Any, args: List[str], available_model_names: List[str]) -> None:

--- a/src/jrdev/core/application.py
+++ b/src/jrdev/core/application.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import json
 import os

--- a/src/jrdev/core/application.py
+++ b/src/jrdev/core/application.py
@@ -457,6 +457,15 @@ class Application:
         self.ui.model_list_updated()
         return True
 
+    def set_model_quantizations(self, model_name: str, quantizations: List[str]) -> bool:
+        """Set OpenRouter provider quantization filters for a model and flush to disk."""
+        if not self.state.model_list.update_model_quantizations(model_name, quantizations):
+            return False
+
+        save_models(self.state.model_list.get_model_list())
+        self.ui.model_list_updated()
+        return True
+
     def refresh_model_list(self):
         # 1) grab every model from user's config (single source of truth)
         models = load_models()

--- a/src/jrdev/core/application.py
+++ b/src/jrdev/core/application.py
@@ -584,9 +584,10 @@ class Application:
 
         # 3) stream the LLM response
         content = f"{USER_INPUT_PREFIX}{user_input}"
+        response_model = self.state.model
         async for chunk in self.message_service.stream_message(msg_thread, content, worker_id):
             # for each piece of text we hand it off to the UI
-            self.ui.stream_chunk(thread_id, chunk)
+            self.ui.stream_chunk(thread_id, chunk, response_model)
         # 4) at the end, notify UI to refresh thread list or button state
         self.ui.chat_thread_update(thread_id)
 

--- a/src/jrdev/messages/message_builder.py
+++ b/src/jrdev/messages/message_builder.py
@@ -11,7 +11,7 @@ logger = logging.getLogger("jrdev")
 class MessageBuilder:
     def __init__(self, app: Any):
         self.app = app
-        self.messages: List[Dict[str, str]] = []
+        self.messages: List[Dict[str, Any]] = []
         self.files: Set[str] = set()
         self.project_files: Set[str] = set()
         self.include_tree: bool = False
@@ -33,7 +33,7 @@ class MessageBuilder:
         """Add an assistant message to the conversation"""
         self.messages.append({"role": "assistant", "content": content})
 
-    def add_historical_messages(self, messages: List[Dict[str, str]]) -> None:
+    def add_historical_messages(self, messages: List[Dict[str, Any]]) -> None:
         """Add historical message chain"""
         self.messages.extend(messages)
 
@@ -176,7 +176,7 @@ class MessageBuilder:
     def clean(self) -> None:
         self.messages = [m for m in self.messages if m["content"] != ""]
 
-    def build(self) -> List[Dict[str, str]]:
+    def build(self) -> List[Dict[str, Any]]:
         """Return the fully constructed message list"""
         if not self.isUserSectionFinal:
             self.finalize_user_section()

--- a/src/jrdev/messages/thread.py
+++ b/src/jrdev/messages/thread.py
@@ -37,7 +37,7 @@ class MessageThread:
         """
         self.thread_id: str = thread_id
         self.name: Optional[str] = None
-        self.messages: List[Dict[str, str]] = []
+        self.messages: List[Dict[str, Any]] = []
         self.context: Set[str] = set()
         self.embedded_files: Set[str] = set()
         self.token_usage: Dict[str, int] = {"input": 0, "output": 0}
@@ -171,31 +171,44 @@ class MessageThread:
         self.metadata["last_modified"] = datetime.now()
 
     @auto_persist
-    def add_response(self, response: str) -> None:
+    def add_response(self, response: str, model: Optional[str] = None) -> None:
         """Add a complete assistant response to the thread history."""
-        self.messages.append({"role": "assistant", "content": response})
+        message = {"role": "assistant", "content": response}
+        if model:
+            message["model"] = model
+        self.messages.append(message)
         self.metadata["last_modified"] = datetime.now()
 
     @auto_persist
-    def add_response_partial(self, chunk: str) -> None:
+    def add_response_partial(self, chunk: str, model: Optional[str] = None) -> None:
         """Add a partial assistant response chunk to the thread history."""
         if self.messages and self.messages[-1].get("role") == "assistant":
             self.messages[-1]["content"] += chunk
+            if model:
+                self.messages[-1]["model"] = model
         else:
-            self.messages.append({"role": "assistant", "content": chunk})
+            message = {"role": "assistant", "content": chunk}
+            if model:
+                message["model"] = model
+            self.messages.append(message)
         self.metadata["last_modified"] = datetime.now()
 
     @auto_persist
-    def finalize_response(self, full_text: str) -> None:
+    def finalize_response(self, full_text: str, model: Optional[str] = None) -> None:
         """Finalize the assistant response, replacing partials with full text."""
         if self.messages and self.messages[-1].get("role") == "assistant":
             self.messages[-1]["content"] = full_text
+            if model:
+                self.messages[-1]["model"] = model
         else:
-            self.messages.append({"role": "assistant", "content": full_text})
+            message = {"role": "assistant", "content": full_text}
+            if model:
+                message["model"] = model
+            self.messages.append(message)
         self.metadata["last_modified"] = datetime.now()
 
     @auto_persist
-    def set_compacted(self, messages: List[Dict[str, str]]) -> None:
+    def set_compacted(self, messages: List[Dict[str, Any]]) -> None:
         """Replace the existing messages list and reset file states."""
         self.messages = messages
         self.context = set()

--- a/src/jrdev/models/model_list.py
+++ b/src/jrdev/models/model_list.py
@@ -75,6 +75,18 @@ class ModelList:
                     return True
             return False
 
+    def update_model_quantizations(self, model_name: str, quantizations: List[str]) -> bool:
+        """
+        Update OpenRouter provider quantization filters for an existing model.
+        Returns True if the model was updated, False if the model was not found.
+        """
+        with self._lock:
+            for m in self._model_list:
+                if m["name"] == model_name:
+                    m["quantizations"] = quantizations
+                    return True
+            return False
+
     def add_model(self, model_name: str, provider: str, is_think: bool, input_cost: int, output_cost: int, context_window: int) -> bool:
         """
         Add a new model to the model list if it does not already exist.

--- a/src/jrdev/services/llm_requests.py
+++ b/src/jrdev/services/llm_requests.py
@@ -6,8 +6,18 @@ from jrdev.services.streaming.google_stream import stream_gemini_format
 from jrdev.services.streaming.openai_stream import stream_openai_format
 
 
+def _provider_messages(messages):
+    """Return provider-safe chat messages without local persistence metadata."""
+    return [
+        {"role": msg["role"], "content": msg["content"]}
+        for msg in messages
+        if "role" in msg and "content" in msg
+    ]
+
+
 def stream_request(app, model, messages, task_id=None, print_stream=True, json_output=False, max_output_tokens=None) -> AsyncIterator[str]:
     """Route a streaming LLM request to the appropriate provider based on the model."""
+    messages = _provider_messages(messages)
     model_provider = None
     for entry in app.get_models():
         if entry["name"] == model:

--- a/src/jrdev/services/message_service.py
+++ b/src/jrdev/services/message_service.py
@@ -63,9 +63,10 @@ class MessageService:
         response_accumulator = ""
         try:
             # stream_request returns an async generator directly as per refactoring note (b)
+            response_model = self.app.state.model
             llm_response_stream = stream_request(
                 self.app,
-                self.app.state.model,
+                response_model,
                 messages_for_llm,
                 task_id
             )
@@ -81,18 +82,18 @@ class MessageService:
                         yield "Thinking..."
                     else:
                         response_accumulator += chunk
-                        msg_thread.add_response_partial(chunk)  # Update thread with partial assistant response
+                        msg_thread.add_response_partial(chunk, model=response_model)  # Update thread with partial assistant response
                         yield chunk
                 elif in_think:
                     if chunk == "</think>":
                         in_think = False
                 else:
                     response_accumulator += chunk
-                    msg_thread.add_response_partial(chunk) # Update thread with partial assistant response
+                    msg_thread.add_response_partial(chunk, model=response_model) # Update thread with partial assistant response
                     yield chunk
 
             # Finalize the full response in the message thread
-            msg_thread.finalize_response(response_accumulator.strip())
+            msg_thread.finalize_response(response_accumulator.strip(), model=response_model)
         except Exception as e:
             logger.error("Message Service: %s", e)
             if task_id:

--- a/src/jrdev/services/streaming/openai_stream.py
+++ b/src/jrdev/services/streaming/openai_stream.py
@@ -14,12 +14,14 @@ async def stream_openai_format(app, model, messages, task_id=None, print_stream=
     app.logger.info(log_msg)
 
     # Get the appropriate client
+    model_info = None
     model_provider = None
 
     # Find the model in AVAILABLE_MODELS
     available_models = app.get_models()
     for entry in available_models:
         if entry["name"] == model:
+            model_info = entry
             model_provider = entry["provider"]
             break
 
@@ -61,6 +63,10 @@ async def stream_openai_format(app, model, messages, task_id=None, print_stream=
             kwargs["response_format"] = {"type": "json_object"}
     elif model_provider == "venice":
         kwargs["extra_body"] = {"venice_parameters": {"include_venice_system_prompt": False}}
+    elif model_provider == "open_router" and model_info:
+        quantizations = model_info.get("quantizations")
+        if isinstance(quantizations, list) and quantizations and all(isinstance(item, str) for item in quantizations):
+            kwargs["extra_body"] = {"provider": {"quantizations": quantizations}}
 
     stream = await client.chat.completions.create(**kwargs)
 

--- a/src/jrdev/ui/cli_events.py
+++ b/src/jrdev/ui/cli_events.py
@@ -22,13 +22,14 @@ class CliEvents(UiWrapper):
         if self.capture_active:
             self.capture += message
 
-    def stream_chunk(self, thread_id: str, chunk: str) -> None:
+    def stream_chunk(self, thread_id: str, chunk: str, model: Optional[str] = None) -> None:
         """
         Handle an incoming chunk of text from a streaming LLM response.
         
         Args:
             thread_id: The ID of the conversation thread this chunk belongs to.
             chunk: The piece of text from the AI's response.
+            model: Optional model name associated with the response.
         """
         terminal_print(chunk, PrintType.LLM, end="", flush=True)
         

--- a/src/jrdev/ui/tui/chat/chat_view_widget.py
+++ b/src/jrdev/ui/tui/chat/chat_view_widget.py
@@ -288,7 +288,7 @@ class ChatViewWidget(Widget):
             else:
                 display_content = body
             
-            bubble = MessageBubble(display_content, role=role)
+            bubble = MessageBubble(display_content, role=role, model=msg.get("model"))
             await self.message_scroller.mount(bubble)
 
         await self._prune_bubbles()
@@ -318,11 +318,17 @@ class ChatViewWidget(Widget):
 
         bubbles = [child for child in self.message_scroller.children if isinstance(child, MessageBubble)]
         last_bubble = bubbles[-1] if bubbles else None
+        model = event.model
+        if not model and active_thread.messages:
+            latest_message = active_thread.messages[-1]
+            if latest_message.get("role") == "assistant":
+                model = latest_message.get("model")
 
         if last_bubble and last_bubble.role == "assistant":
+            last_bubble.set_model(model)
             last_bubble.append_chunk(event.chunk)
         else:
-            new_bubble = MessageBubble(event.chunk, role="assistant")
+            new_bubble = MessageBubble(event.chunk, role="assistant", model=model)
             await self.message_scroller.mount(new_bubble)
             await self._prune_bubbles()
 

--- a/src/jrdev/ui/tui/chat/message_bubble.py
+++ b/src/jrdev/ui/tui/chat/message_bubble.py
@@ -33,10 +33,17 @@ class MessageBubble(Vertical):
     }
     """
 
-    def __init__(self, message_content: str, role: str, id: str | None = None) -> None:
+    def __init__(
+        self,
+        message_content: str,
+        role: str,
+        id: str | None = None,
+        model: str | None = None
+    ) -> None:
         super().__init__(id=id)
         self.message_content = message_content
         self.role = role
+        self.model = model
         self.is_thinking = message_content == "Thinking..."
 
         border_color_map = {
@@ -68,7 +75,7 @@ class MessageBubble(Vertical):
             self.border_title = "Me"
         else:
             self.styles.border = ("round", Color.parse("#27dfd0"))
-            self.border_title = "Assistant"
+            self.border_title = self.model or "Assistant"
 
     @on(Button.Pressed)
     async def handle_copy_button(self, event: Button.Pressed) -> None:
@@ -101,3 +108,10 @@ class MessageBubble(Vertical):
 
         # add the new text
         self.text_area.append_text(chunk)
+
+    def set_model(self, model: str | None) -> None:
+        """Set the displayed model name for assistant messages."""
+        if self.role != "assistant" or not model:
+            return
+        self.model = model
+        self.border_title = model

--- a/src/jrdev/ui/tui/chat/message_bubble.py
+++ b/src/jrdev/ui/tui/chat/message_bubble.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pyperclip
 import logging
 

--- a/src/jrdev/ui/tui/settings/model_management/base_model_modal.py
+++ b/src/jrdev/ui/tui/settings/model_management/base_model_modal.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from textual.screen import ModalScreen
 from textual.widgets import Input, Button, Label, Select
 from textual.containers import Vertical, Horizontal

--- a/src/jrdev/ui/tui/terminal/bordered_switcher.py
+++ b/src/jrdev/ui/tui/terminal/bordered_switcher.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from textual.widgets import ContentSwitcher
 
 

--- a/src/jrdev/ui/tui/terminal/terminal_text_area.py
+++ b/src/jrdev/ui/tui/terminal/terminal_text_area.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import re
 from typing import Dict

--- a/src/jrdev/ui/tui/textual_events.py
+++ b/src/jrdev/ui/tui/textual_events.py
@@ -58,10 +58,11 @@ class TextualEvents(UiWrapper):
 
     class StreamChunk(Message):
         """Fired once per text-chunk from the LLM."""
-        def __init__(self, thread_id: str, chunk: str):
+        def __init__(self, thread_id: str, chunk: str, model: Optional[str] = None):
             super().__init__()
             self.thread_id = thread_id
             self.chunk = chunk
+            self.model = model
 
     class ConfirmationRequest(Message):
         def __init__(self, prompt_text: str, future: asyncio.Future, diff_lines: Optional[List[str]] = None, error_msg: str = None):
@@ -224,9 +225,9 @@ class TextualEvents(UiWrapper):
         """Signal to UI that project context has been toggled on or off"""
         self.app.post_message(self.ProjectContextUpdate(is_enabled))
 
-    def stream_chunk(self, thread_id: str, chunk: str) -> None:
+    def stream_chunk(self, thread_id: str, chunk: str, model: Optional[str] = None) -> None:
         """Post a chunk event into Textual's event bus."""
-        self.app.post_message(self.StreamChunk(thread_id, chunk))
+        self.app.post_message(self.StreamChunk(thread_id, chunk, model))
 
     def providers_updated(self) -> None:
         """Providers has been changed (add/delete/edit)"""

--- a/src/jrdev/ui/tui/textual_ui.py
+++ b/src/jrdev/ui/tui/textual_ui.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from jrdev.ui.tui.model_listview import ModelListView
 from jrdev.ui.ui import printtype_to_string
 from textual import on, events

--- a/src/jrdev/ui/ui_wrapper.py
+++ b/src/jrdev/ui/ui_wrapper.py
@@ -15,13 +15,14 @@ class UiWrapper:
         """print a stream of text"""
         raise NotImplementedError("Subclasses must implement print_stream()")
 
-    def stream_chunk(self, thread_id: str, chunk: str) -> None:
+    def stream_chunk(self, thread_id: str, chunk: str, model: Optional[str] = None) -> None:
         """
         Handle an incoming chunk of text from a streaming LLM response.
         
         Args:
             thread_id: The ID of the conversation thread this chunk belongs to.
             chunk: The piece of text from the AI's response.
+            model: Optional model name associated with the response.
         """
         raise NotImplementedError("Subclasses must implement stream_chunk()")
 

--- a/tests/test_commands_model.py
+++ b/tests/test_commands_model.py
@@ -35,6 +35,7 @@ class DummyApp:
         self.added_models = []
         self.removed_models = []
         self.edited_models = []
+        self.quantization_models = []
         self.failed_remove = False
     def get_model_names(self):
         return [m["name"] for m in self._models]
@@ -79,12 +80,21 @@ class DummyApp:
                 self.edited_models.append(name)
                 return True
         return False
+    def set_model_quantizations(self, name, quantizations):
+        for m in self._models:
+            if m["name"] == name:
+                m["quantizations"] = quantizations
+                self.quantization_models.append(name)
+                return True
+        return False
+
 
 class TestModelCommand(unittest.TestCase):
     def setUp(self):
         self.default_models = [
             {"name": "gpt-4", "provider": "openai", "is_think": True, "input_cost": 1, "output_cost": 2, "context_tokens": 8192},
-            {"name": "gpt-3.5", "provider": "openai", "is_think": False, "input_cost": 1, "output_cost": 2, "context_tokens": 4096}
+            {"name": "gpt-3.5", "provider": "openai", "is_think": False, "input_cost": 1, "output_cost": 2, "context_tokens": 4096},
+            {"name": "openai/glm-5", "provider": "open_router", "is_think": True, "input_cost": 1, "output_cost": 2, "context_tokens": 128000}
         ]
         self.app = DummyApp(models=[m.copy() for m in self.default_models], model="gpt-4")
 
@@ -93,7 +103,7 @@ class TestModelCommand(unittest.TestCase):
         out = "\n".join(msg for msg, _ in self.app.ui.printed)
         self.assertIn("Current chat model: gpt-4", out)
         self.assertIn("/model list", out)
-        self.assertIn("Available models: gpt-4, gpt-3.5", out)
+        self.assertIn("Available models: gpt-4, gpt-3.5, openai/glm-5", out)
 
     def test_list_models(self):
         run_async(model_cmd.handle_model(self.app, ["/model", "list"], "w1"))
@@ -101,6 +111,7 @@ class TestModelCommand(unittest.TestCase):
         self.assertIn("Available models (from your user_models.json):", out)
         self.assertIn("  - gpt-4", out)
         self.assertIn("  - gpt-3.5", out)
+        self.assertIn("  - openai/glm-5", out)
 
     def test_list_models_empty(self):
         app = DummyApp(models=[])
@@ -119,7 +130,7 @@ class TestModelCommand(unittest.TestCase):
         run_async(model_cmd.handle_model(self.app, ["/model", "set"], "w1"))
         out = "\n".join(msg for msg, _ in self.app.ui.printed)
         self.assertIn("Usage: /model set <model_name>", out)
-        self.assertIn("Available models: gpt-4, gpt-3.5", out)
+        self.assertIn("Available models: gpt-4, gpt-3.5, openai/glm-5", out)
 
     def test_set_model_not_found(self):
         run_async(model_cmd.handle_model(self.app, ["/model", "set", "notfound"], "w1"))
@@ -433,6 +444,31 @@ class TestModelCommand(unittest.TestCase):
         out = "\n".join(msg for msg, _ in self.app.ui.printed)
         self.assertIn("context_window must be between 1 and 1,000,000,000", out)
         self.assertEqual(len(self.app.edited_models), 0)
+
+    def test_set_openrouter_quantizations_success(self):
+        args = ["/model", "openai/glm-5", "quantizations", "[int4,", "int8]"]
+        run_async(model_cmd.handle_model(self.app, args, "w1"))
+        model = next(m for m in self.app.get_models() if m["name"] == "openai/glm-5")
+        self.assertEqual(model["quantizations"], ["int4", "int8"])
+        self.assertIn("openai/glm-5", self.app.quantization_models)
+        out = "\n".join(msg for msg, _ in self.app.ui.printed)
+        self.assertIn("Set quantizations for model 'openai/glm-5' to: int4, int8", out)
+
+    def test_set_quantizations_rejects_non_openrouter_model(self):
+        args = ["/model", "gpt-4", "quantizations", "[int4,", "int8]"]
+        run_async(model_cmd.handle_model(self.app, args, "w1"))
+        model = next(m for m in self.app.get_models() if m["name"] == "gpt-4")
+        self.assertNotIn("quantizations", model)
+        out = "\n".join(msg for msg, _ in self.app.ui.printed)
+        self.assertIn("Quantizations can only be set for OpenRouter models", out)
+
+    def test_set_quantizations_rejects_empty_list(self):
+        args = ["/model", "openai/glm-5", "quantizations", "[]"]
+        run_async(model_cmd.handle_model(self.app, args, "w1"))
+        model = next(m for m in self.app.get_models() if m["name"] == "openai/glm-5")
+        self.assertNotIn("quantizations", model)
+        out = "\n".join(msg for msg, _ in self.app.ui.printed)
+        self.assertIn("Invalid quantizations", out)
 
 
 if __name__ == "__main__":

--- a/tests/test_commands_model.py
+++ b/tests/test_commands_model.py
@@ -15,7 +15,7 @@ from jrdev.commands import model as model_cmd
 
 # Helper: run async function in sync test
 def run_async(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 class DummyUI:
     def __init__(self):

--- a/tests/test_openai_stream.py
+++ b/tests/test_openai_stream.py
@@ -1,0 +1,102 @@
+import asyncio
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+
+from jrdev.services.streaming.openai_stream import stream_openai_format
+
+
+def run_async(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class FakeUsage:
+    async def add_use(self, _model, _input_tokens, _output_tokens):
+        return None
+
+
+class FakeStream:
+    def __aiter__(self):
+        self._chunks = iter(
+            [
+                SimpleNamespace(
+                    choices=[SimpleNamespace(delta=SimpleNamespace(content="ok"))],
+                    usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+                )
+            ]
+        )
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._chunks)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+class FakeCompletions:
+    def __init__(self):
+        self.kwargs = None
+
+    async def create(self, **kwargs):
+        self.kwargs = kwargs
+        return FakeStream()
+
+
+class FakeClient:
+    def __init__(self):
+        self.completions = FakeCompletions()
+        self.chat = SimpleNamespace(completions=self.completions)
+
+
+class FakeClients:
+    def __init__(self, client):
+        self.client = client
+
+    def get_all_clients(self):
+        return {"open_router": self.client}
+
+    def get_client(self, provider):
+        if provider == "open_router":
+            return self.client
+        return None
+
+
+class TestOpenAIStream(unittest.TestCase):
+    def test_openrouter_quantizations_sent_as_provider_routing(self):
+        client = FakeClient()
+        app = SimpleNamespace(
+            logger=MagicMock(),
+            ui=MagicMock(),
+            state=SimpleNamespace(clients=FakeClients(client)),
+            get_models=lambda: [
+                {
+                    "name": "openai/glm-5",
+                    "provider": "open_router",
+                    "quantizations": ["int4", "int8"],
+                }
+            ],
+        )
+
+        async def consume():
+            chunks = []
+            async for chunk in stream_openai_format(app, "openai/glm-5", [{"role": "user", "content": "hi"}]):
+                chunks.append(chunk)
+            return "".join(chunks)
+
+        with patch("jrdev.services.streaming.openai_stream.get_instance", return_value=FakeUsage()):
+            response = run_async(consume())
+
+        self.assertEqual(response, "ok")
+        self.assertEqual(
+            client.completions.kwargs["extra_body"],
+            {"provider": {"quantizations": ["int4", "int8"]}},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openai_stream.py
+++ b/tests/test_openai_stream.py
@@ -11,7 +11,7 @@ from jrdev.services.streaming.openai_stream import stream_openai_format
 
 
 def run_async(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 class FakeUsage:


### PR DESCRIPTION
## Overview
This pull request introduces two complementary improvements to the codebase. First, it adds support for configuring quantization filters specifically for OpenRouter models, allowing users to control which quantized versions of a model the provider may serve. Second, it ensures that the model name used to generate each assistant response is recorded in the message thread and displayed in the UI, giving users immediate visibility into which model produced a given response. Along the way, several related changes improve error handling, maintainability, and test coverage.

## What This Means for Users
- **New `/model` subcommand for OpenRouter quantization** – Users can now restrict an OpenRouter model to specific quantizations (e.g., `int4`, `int8`) by running `/model <model_name> quantizations [int4, int8]`. This helps control inference speed, cost, and quality when using OpenRouter.
- **Model name visible in assistant message bubbles** – In the Textual TUI, each assistant message now shows the model name in the bubble’s border title. This provides immediate context about which model generated the response.
- **Improved error robustness** – The agent pipeline now catches additional error types (e.g., `json.JSONDecodeError`, `TypeError`) when parsing JSON responses, reducing the chance of crashes from malformed output.

## A Closer Look at the Changes

### Error Handling Improvements
- **`fetch_context_phase.py`** – Moved `json.loads(json_content)` inside the `try` block and extended the exception tuple to include `json.JSONDecodeError` and `TypeError` in addition to `AttributeError`. This prevents crashes when the LLM returns non‑JSON content or unexpected data structures.

### Model Tracking in Threads
- **`messages/thread.py`** – The `add_response`, `add_response_partial`, and `finalize_response` methods now accept an optional `model` parameter. When provided, the model name is stored alongside the message in the thread’s message list.
- **`messages/message_builder.py`** – Type annotations were updated to reflect that message dictionaries can now contain a `"model"` key alongside the standard `"role"` and `"content"`.
- **`message_service.py`** – The streaming response path now consistently passes the active model name (`response_model`) to all thread update methods, ensuring the model is recorded during streaming and finalization.
- **`commands/compact.py`** – When compacting a thread, the new assistant message now includes a `"model"` field (taken from the original compacted data) to preserve model information across compaction.

### OpenRouter Quantization Support
- **`commands/model.py`** – Added a new `_parse_quantizations` helper and a `_handle_quantizations` function that processes the `/model <name> quantizations [...]` subcommand. The command validates that the target model uses the OpenRouter provider and that the quantization list is well‑formed.
- **`models/model_list.py`** – Introduced `update_model_quantizations` to modify the `"quantizations"` field of an existing model entry in the in‑memory list and persist it to disk.
- **`core/application.py`** – Added `set_model_quantizations` as a public method that delegates to `ModelList` and triggers a UI refresh.
- **`services/streaming/openai_stream.py`** – When the model provider is `"open_router"` and the model entry contains a non‑empty `"quantizations"` list, the stream request now includes an `extra_body` with `{"provider": {"quantizations": [...]}}`. This tells the OpenRouter API to only use the specified quantization levels.
- **`services/llm_requests.py`** – Added `_provider_messages` to strip out any non‑essential keys (such as `"model"`) from messages before they are sent to the LLM provider. This ensures that internal metadata does not leak into provider‑side message formatting.

### UI Model Display
- **`ui/ui_wrapper.py`, `ui/cli_events.py`, `ui/tui/textual_events.py`** – The `stream_chunk` method now accepts an optional `model` parameter, which is forwarded to the TUI event system.
- **`ui/tui/chat/chat_view_widget.py`** – The `StreamChunk` event handler uses the provided `model` (or falls back to the latest assistant message’s model) when creating or updating `MessageBubble` widgets.
- **`ui/tui/chat/message_bubble.py`** – The `MessageBubble` class now stores a `model` attribute and sets the bubble’s border title to the model name for assistant messages. A `set_model` method allows updating the model name after creation.

### Help Text & Documentation
- **`commands/help.py`** – Updated the inline help text for `/model` to include the quantizations subcommand, showing the full usage syntax.

### Test Coverage
- **`tests/test_commands_model.py`** – Added test cases for setting quantizations on an OpenRouter model, rejecting invalid providers, and rejecting empty quantization lists. A new OpenRouter model entry was added to the test fixtures.
- **`tests/test_openai_stream.py`** – New test file that verifies the OpenRouter quantization parameter is correctly included in the API request `extra_body` when the model has a quantization list configured.

`Generated by JrDev AI using deepseek-v4-flash`